### PR TITLE
Fix manual homework completion button activation

### DIFF
--- a/index.html
+++ b/index.html
@@ -3670,12 +3670,17 @@
                 resultMessage.textContent = '코드를 확인하는 중...';
                 const verifyCodeFunction = httpsCallable(functions, 'verifyCode');
                 const result = await verifyCodeFunction({ code });
+                const completeBtn = document.getElementById('complete-manual-problem-btn');
                 if (result.data.success) {
                     resultMessage.textContent = result.data.message;
                     resultMessage.style.color = 'green';
+                    completeBtn.classList.remove('btn-disabled');
+                    completeBtn.disabled = false;
                 } else {
                     resultMessage.textContent = result.data.message || '알 수 없는 오류가 발생했습니다.';
                     resultMessage.style.color = 'red';
+                    completeBtn.classList.add('btn-disabled');
+                    completeBtn.disabled = true;
                 }
             } catch (error) {
                 console.error('코드 검증 상세 오류:', error);


### PR DESCRIPTION
## Summary
- enable manual homework completion button when proof code verification succeeds
- disable the button on verification failure

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6875fe32e7f0832eb942ff9184d84a7d