### PR TITLE
feat: update Gemini API key

### DIFF
--- a/index.html
+++ b/index.html
@@ -3608,7 +3608,7 @@
         }
 
         async function callGemini(prompt, json = false) {
-            const apiKey = "AIzaSyC7_Gq4LIVVMv0hMD6qSwcTlGJcDSt-KgI";
+            const apiKey = "AIzaSyCKm4OuGThasWYYuj6CdwprWeRzTv3rEfQ";
             const apiUrl = `https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent?key=${apiKey}`;
             const payload = { contents: [{ role: 'user', parts: [{ text: prompt }] }], generationConfig: json ? { responseMimeType: 'application/json' } : {} };
             try {


### PR DESCRIPTION
## Summary
- replace legacy Gemini API key with newly provided value for `callGemini`

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688cbc056cf4832ebaa6d67fa9b77943