### PR TITLE
refactor: route Gemini API through Netlify function

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,3 @@
+[build]
+  publish = "public"
+  functions = "netlify/functions/"

--- a/netlify/functions/gemini-handler.js
+++ b/netlify/functions/gemini-handler.js
@@ -1,0 +1,36 @@
+const fetch = (...args) => import('node-fetch').then(({default: fetch}) => fetch(...args));
+
+exports.handler = async (event) => {
+  if (event.httpMethod !== 'POST') {
+    return { statusCode: 405, body: 'Method Not Allowed' };
+  }
+
+  try {
+    // The GEMINI_API_KEY is securely accessed from Netlify's environment variables.
+    const { GEMINI_API_KEY } = process.env;
+    const payload = event.body; // The frontend payload is passed directly.
+
+    const response = await fetch(`https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent?key=${GEMINI_API_KEY}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: payload,
+    });
+
+    const data = await response.json();
+    if (!response.ok) {
+        // Forward the error message from Google's API if available
+        throw new Error(data.error?.message || 'Gemini API Error');
+    }
+
+    return {
+        statusCode: 200,
+        body: JSON.stringify(data)
+    };
+
+  } catch (error) {
+    return {
+        statusCode: 500,
+        body: JSON.stringify({ error: error.message })
+    };
+  }
+};

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "aiedue",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "dependencies": {
+    "node-fetch": "^3.3.2"
+  }
+}

--- a/public/index.html
+++ b/public/index.html
@@ -1441,11 +1441,9 @@
             const stockName = stockDataCache[stockId].name;
             const prompt = `초등학생을 위한 ${stockName}에 대한 짧고 재미있는 이야기를 만들어줘. 예를 들어, ${stockName}이 왜 오르거나 내릴 수 있는지, 또는 ${stockName}과 관련된 재미있는 상상을 덧붙여서 이야기해줘. 긍정적이고 희망찬 내용으로 작성해줘. 100자 이내로 짧게 부탁해.`;
             showAiModal("✨ AI가 열심히 생각하고 있어요...");
-            const apiKey = "AIzaSyC7_Gq4LIVVMv0hMD6qSwcTlGJcDSt-KgI";
-            const apiUrl = `https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent?key=${apiKey}`;
             const payload = { contents: [{ role: "user", parts: [{ text: prompt }] }] };
             try {
-                const response = await fetch(apiUrl, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(payload) });
+                const response = await fetch('/.netlify/functions/gemini-handler', { method: 'POST', body: JSON.stringify(payload) });
                 if (!response.ok) throw new Error(`API 요청 실패 (상태 코드: ${response.status})`);
                 const result = await response.json();
                 updateAiModalContent(result.candidates?.[0]?.content?.parts?.[0]?.text || 'AI 응답 생성 실패');
@@ -2592,15 +2590,13 @@
             const displayArea = document.getElementById('problem-display-area');
             displayArea.innerHTML = `<div class="flex items-center justify-center p-4"><div class="loading-spinner"></div><p class="ml-2">AI가 문제를 만들고 있습니다...</p></div>`;
 
-            const apiKey = "AIzaSyC7_Gq4LIVVMv0hMD6qSwcTlGJcDSt-KgI";
-            const apiUrl = `https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent?key=${apiKey}`;
             const payload = {
                 contents: [{ role: "user", parts: [{ text: prompt }] }],
                 generationConfig: { responseMimeType: "application/json" }
             };
-            
+
             try {
-                const response = await fetch(apiUrl, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(payload) });
+                const response = await fetch('/.netlify/functions/gemini-handler', { method: 'POST', body: JSON.stringify(payload) });
                 if (!response.ok) throw new Error(`API 요청 실패 (상태 코드: ${response.status})`);
                 const result = await response.json();
                 const jsonString = result.candidates[0].content.parts[0].text;
@@ -3618,11 +3614,9 @@
         }
 
         async function callGemini(prompt, json = false) {
-            const apiKey = "AIzaSyCKm4OuGThasWYYuj6CdwprWeRzTv3rEfQ";
-            const apiUrl = `https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent?key=${apiKey}`;
             const payload = { contents: [{ role: 'user', parts: [{ text: prompt }] }], generationConfig: json ? { responseMimeType: 'application/json' } : {} };
             try {
-                const response = await fetch(apiUrl, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(payload) });
+                const response = await fetch('/.netlify/functions/gemini-handler', { method: 'POST', body: JSON.stringify(payload) });
                 const result = await response.json();
                 const text = result.candidates?.[0]?.content?.parts?.[0]?.text || '';
                 if(json) return JSON.parse(text);
@@ -3775,15 +3769,13 @@
             document.getElementById('dictation-footer').style.display = 'flex';
 
 
-            const apiKey = "AIzaSyC7_Gq4LIVVMv0hMD6qSwcTlGJcDSt-KgI";
-            const apiUrl = `https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent?key=${apiKey}`;
             const payload = {
                 contents: [{ role: "user", parts: [{ text: prompt }] }],
                 generationConfig: { responseMimeType: "application/json" }
             };
 
             try {
-                const response = await fetch(apiUrl, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(payload) });
+                const response = await fetch('/.netlify/functions/gemini-handler', { method: 'POST', body: JSON.stringify(payload) });
                 if (!response.ok) throw new Error(`API 요청 실패 (상태 코드: ${response.status})`);
                 const result = await response.json();
                 const jsonString = result.candidates[0].content.parts[0].text;


### PR DESCRIPTION
## Summary
- move app into `public` and secure Gemini API calls through a Netlify serverless function
- add Netlify config and Node setup with `node-fetch`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6890736166a0832e81d73270c4ee6ced