### PR TITLE
Redirect book activity to dedicated page with Stability image generation

### DIFF
--- a/netlify/functions/stability-handler.js
+++ b/netlify/functions/stability-handler.js
@@ -1,0 +1,39 @@
+const fetch = (...args) => import('node-fetch').then(({default: fetch}) => fetch(...args));
+
+exports.handler = async (event) => {
+  if (event.httpMethod !== 'POST') {
+    return { statusCode: 405, body: 'Method Not Allowed' };
+  }
+
+  try {
+    const { Stability_api_key } = process.env;
+    const { prompt } = JSON.parse(event.body || '{}');
+
+    const response = await fetch('https://api.stability.ai/v2beta/stable-image/generate', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Accept': 'application/json',
+        'Authorization': `Bearer ${Stability_api_key}`
+      },
+      body: JSON.stringify({
+        text_prompts: [{ text: prompt }]
+      })
+    });
+
+    const data = await response.json();
+    if (!response.ok) {
+      throw new Error(data.error?.message || 'Stability API Error');
+    }
+
+    return {
+      statusCode: 200,
+      body: JSON.stringify(data)
+    };
+  } catch (error) {
+    return {
+      statusCode: 500,
+      body: JSON.stringify({ error: error.message })
+    };
+  }
+};

--- a/public/book.html
+++ b/public/book.html
@@ -32,7 +32,10 @@
     <div id="book-viewer-page" class="page-content max-w-7xl mx-auto">
         <div class="bg-white rounded-2xl shadow-lg p-4 md:p-6">
             <header class="flex flex-col sm:flex-row justify-between items-center mb-4 gap-4">
-                <h1 class="text-2xl md:text-4xl font-bold text-emerald-800">AI 책 만들기</h1>
+                <div class="flex items-end gap-2">
+                    <h1 class="text-2xl md:text-4xl font-bold text-emerald-800">AI 책 만들기</h1>
+                    <span class="text-sm text-gray-600">글쓴이: <span id="author-display" class="book-author-sync"></span></span>
+                </div>
                 <div id="viewer-controls" class="flex flex-wrap justify-center items-center gap-2">
                     <button onclick="addManualPage()" class="bg-cyan-500 text-white font-bold py-2 px-4 rounded-lg hover:bg-cyan-600">+ 페이지 추가</button>
                     <button onclick="deleteCurrentPage()" class="bg-red-500 text-white font-bold py-2 px-4 rounded-lg hover:bg-red-600">페이지 삭제</button>
@@ -89,11 +92,23 @@
          * 실제로는 서버에 요청을 보내야 하지만, 여기서는 플레이스홀더 이미지 URL을 반환합니다.
          */
         async function generateImageForParagraph(text, context = "") {
-            console.log(`이미지 생성 요청: "${text}" (컨텍스트: "${context}")`);
-            // AI가 이미지를 생성하는 것처럼 보이도록 약간의 딜레이를 줍니다.
-            await new Promise(resolve => setTimeout(resolve, 1000)); 
-            const placeholderText = `"${text.substring(0, 20)}..."`;
-            return `https://placehold.co/1024x1024/d1fae5/10b981?text=${encodeURIComponent(placeholderText)}`;
+            try {
+                const res = await fetch('/.netlify/functions/stability-handler', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ prompt: `${text}\n${context}` })
+                });
+                const data = await res.json();
+                if (!res.ok) {
+                    throw new Error(data.error || 'Stability API Error');
+                }
+                const base64 = data.artifacts?.[0]?.base64;
+                return `data:image/png;base64,${base64}`;
+            } catch (err) {
+                console.error(err);
+                showNotification('이미지 생성 실패');
+                return '';
+            }
         }
 
         // 수동 책 만들기 시작
@@ -513,6 +528,36 @@
         document.addEventListener("click", e => {
             if (e.target.classList.contains("tts-word")) {
                 speak(e.target.textContent.trim());
+            }
+        });
+    </script>
+    <script type="module">
+        import { initializeApp } from "https://www.gstatic.com/firebasejs/11.6.1/firebase-app.js";
+        import { getAuth, onAuthStateChanged } from "https://www.gstatic.com/firebasejs/11.6.1/firebase-auth.js";
+        import { getFirestore, doc, getDoc } from "https://www.gstatic.com/firebasejs/11.6.1/firebase-firestore.js";
+
+        const firebaseConfig = {
+            apiKey: "AIzaSyDCeJPDQUNi-KmJ9DhkTRIu-9t2PGZCpt0",
+            authDomain: "mansungcoin-c6e06.firebaseapp.com",
+            projectId: "mansungcoin-c6e06",
+            storageBucket: "mansungcoin-c6e06.appspot.com",
+            messagingSenderId: "704809284946",
+            appId: "1:704809284946:web:3e71d98f38810577e1768b"
+        };
+
+        const app = initializeApp(firebaseConfig);
+        const auth = getAuth(app);
+        const db = getFirestore(app);
+
+        onAuthStateChanged(auth, async (user) => {
+            if (user) {
+                const userDoc = await getDoc(doc(db, 'users', user.uid));
+                const name = userDoc.data()?.name || '';
+                document.addEventListener('DOMContentLoaded', () => {
+                    document.querySelectorAll('.book-author-sync').forEach(el => el.textContent = name);
+                });
+            } else {
+                window.location.href = 'index.html';
             }
         });
     </script>

--- a/public/index.html
+++ b/public/index.html
@@ -2749,7 +2749,7 @@
                 } else if (hw.type === 'readingJournal') {
                     openReadingJournalModal(hw.id, hw.problemId);
                 } else if (hw.type === 'bookActivity') {
-                    openBookActivityModal(hw.id, hw.problemId);
+                    window.location.href = 'book.html';
                 } else {
                     openHomeworkModal(hw.id, hw.problemId);
                 }
@@ -3180,7 +3180,7 @@
                         } else if (hwType === 'readingJournal') {
                             openReadingJournalModal(e.target.dataset.hwid, e.target.dataset.problemid);
                         } else if (hwType === 'bookActivity') {
-                            openBookActivityModal(e.target.dataset.hwid, e.target.dataset.problemid);
+                            window.location.href = 'book.html';
                         } else {
                             openHomeworkModal(e.target.dataset.hwid, e.target.dataset.problemid);
                         }


### PR DESCRIPTION
## Summary
- Redirect book assignments to `book.html` instead of a modal
- Show author name in book editor header synced with cover page
- Generate illustrations via new Stability API Netlify function using `Stability_api_key`

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68bfa746e7ac832eb9c716056b90fec1