### PR TITLE
Protect first story page from deletion

### DIFF
--- a/public/book.html
+++ b/public/book.html
@@ -322,6 +322,13 @@
                     return;
                 }
             }
+            if (type === 'story') {
+                const storySpreads = Array.from(document.querySelectorAll('#book-viewer .book-spread[data-page-type="story"]'));
+                if (storySpreads.indexOf(currentSpread) === 0) {
+                    showNotification("기본 줄거리 페이지는 삭제할 수 없습니다.");
+                    return;
+                }
+            }
             currentSpread.remove();
             totalBookSpreads--;
             bookCurrentPage = Math.max(0, Math.min(bookCurrentPage, totalBookSpreads - 1));
@@ -434,10 +441,13 @@
     const type = currentSpread.dataset.pageType;
 
     if (type === 'story') {
-        actionContainer.innerHTML = `
-            <button onclick="addManualPage()" class="bg-cyan-500 text-white font-bold py-2 px-4 rounded-lg hover:bg-cyan-600">+ 페이지 추가</button>
-            <button onclick="deleteCurrentPage()" class="bg-red-500 text-white font-bold py-2 px-4 rounded-lg hover:bg-red-600">페이지 삭제</button>
-        `;
+        const storySpreads = Array.from(document.querySelectorAll('#book-viewer .book-spread[data-page-type="story"]'));
+        const storyIndex = storySpreads.indexOf(currentSpread);
+        let buttons = `<button onclick="addManualPage()" class="bg-cyan-500 text-white font-bold py-2 px-4 rounded-lg hover:bg-cyan-600">+ 페이지 추가</button>`;
+        if (storyIndex > 0) {
+            buttons += `<button onclick="deleteCurrentPage()" class="bg-red-500 text-white font-bold py-2 px-4 rounded-lg hover:bg-red-600">페이지 삭제</button>`;
+        }
+        actionContainer.innerHTML = buttons;
     } else if (type === 'character') {
         const charSpreads = Array.from(document.querySelectorAll('#book-viewer .book-spread[data-page-type="character"]'));
         const charIndex = charSpreads.indexOf(currentSpread);


### PR DESCRIPTION
## Summary
- Prevent removal of the initial story page and show a notice instead
- Hide delete button on the first story page; only later pages can be removed

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68bfb18e7074832eb23ccb09a4052fe7