### PR TITLE
Improve error reporting for image generation

### DIFF
--- a/public/book.html
+++ b/public/book.html
@@ -93,23 +93,30 @@
          * 실제로는 서버에 요청을 보내야 하지만, 여기서는 플레이스홀더 이미지 URL을 반환합니다.
          */
         async function generateImageForParagraph(text, context = "") {
+            const res = await fetch('/.netlify/functions/stability-handler', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ prompt: `${text}\n${context}` })
+            });
+
+            let data;
             try {
-                const res = await fetch('/.netlify/functions/stability-handler', {
-                    method: 'POST',
-                    headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify({ prompt: `${text}\n${context}` })
-                });
-                const data = await res.json();
-                if (!res.ok) {
-                    throw new Error(data.error || 'Stability API Error');
-                }
-                const base64 = data.artifacts?.[0]?.base64;
-                return `data:image/png;base64,${base64}`;
-            } catch (err) {
-                console.error(err);
-                showNotification('이미지 생성 실패');
-                return '';
+                data = await res.json();
+            } catch (_) {
+                throw new Error('서버 응답을 파싱하지 못했습니다.');
             }
+
+            if (!res.ok) {
+                const message = data.error?.message || data.error || 'Stability API Error';
+                throw new Error(message);
+            }
+
+            const base64 = data.artifacts?.[0]?.base64;
+            if (!base64) {
+                throw new Error('이미지 데이터가 없습니다.');
+            }
+
+            return `data:image/png;base64,${base64}`;
         }
 
         // 수동 책 만들기 시작


### PR DESCRIPTION
## Summary
- Propagate detailed errors from image generation API
- Show specific failure messages and stop processing when image data is missing

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68bff9d7a874832ea153dc6285872f2c