### PR TITLE
fix: generate book images via POST

### DIFF
--- a/public/book.html
+++ b/public/book.html
@@ -94,7 +94,13 @@
          */
         async function generateImageForParagraph(text, context = "") {
             const prompt = `${text}\n${context}`;
-            const res = await fetch(`/.netlify/functions/stability-handler?prompt=${encodeURIComponent(prompt)}`);
+            const res = await fetch('/.netlify/functions/stability-handler', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json'
+                },
+                body: JSON.stringify({ prompt })
+            });
 
             let data;
             try {


### PR DESCRIPTION
## Summary
- fix manual book creation by POSTing prompts to the `stability-handler`

## Testing
- `npm test` (fails: Error: no test specified)


------
https://chatgpt.com/codex/tasks/task_e_68c002243a04832ea3333752fbe26998