### PR TITLE
Handle binary Stability API responses

### DIFF
--- a/public/book.html
+++ b/public/book.html
@@ -114,7 +114,7 @@
                 throw new Error(message);
             }
 
-            const base64 = data.artifacts?.[0]?.base64;
+            const base64 = data.image || data.artifacts?.[0]?.base64;
             if (!base64) {
                 throw new Error('이미지 데이터가 없습니다.');
             }


### PR DESCRIPTION
## Summary
- Return base64-encoded image data from Stability handler by accepting image responses and encoding them
- Allow book generator to read base64 image data from updated handler

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c003dd0264832eaba4551802b43dac