### PR TITLE
Fix stability image generation request

### DIFF
--- a/netlify/functions/stability-handler.js
+++ b/netlify/functions/stability-handler.js
@@ -2,7 +2,7 @@ const fetch = (...args) => import('node-fetch').then(({default: fetch}) => fetch
 
 exports.handler = async (event) => {
   if (event.httpMethod !== 'POST') {
-    return { statusCode: 405, body: 'Method Not Allowed' };
+    return { statusCode: 405, body: JSON.stringify({ error: 'Method Not Allowed' }) };
   }
 
   try {
@@ -25,7 +25,7 @@ exports.handler = async (event) => {
       return { statusCode: 200, body: JSON.stringify(data) };
     }
 
-    return { statusCode: 400, body: 'Invalid request type. Only "stability" type is supported for image generation.' };
+    return { statusCode: 400, body: JSON.stringify({ error: 'Invalid request type. Only "stability" type is supported for image generation.' }) };
 
   } catch (error) {
     return { statusCode: 500, body: JSON.stringify({ error: error.message }) };

--- a/public/book.html
+++ b/public/book.html
@@ -99,7 +99,17 @@
                 headers: {
                     'Content-Type': 'application/json'
                 },
-                body: JSON.stringify({ prompt })
+                body: JSON.stringify({
+                    type: 'stability',
+                    payload: {
+                        text_prompts: [{ text: prompt }],
+                        cfg_scale: 7,
+                        height: 1024,
+                        width: 1024,
+                        samples: 1,
+                        steps: 30
+                    }
+                })
             });
 
             let data;


### PR DESCRIPTION
## Summary
- Update book page to send structured request with type and payload to Stability handler
- Return JSON errors from stability handler for invalid requests

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c00d6b3b8c832e8a3801863e28c259