### PR TITLE
Fix book activity UID handling and modal display

### DIFF
--- a/public/book.html
+++ b/public/book.html
@@ -68,6 +68,7 @@
         let bookCurrentPage = 0;
         let totalBookSpreads = 0;
         let bookCode = null;
+        let bookAuthorUid = null;
         let auth;
         let db;
         let storage;
@@ -673,17 +674,18 @@
 
         onAuthStateChanged(auth, async (user) => {
             if (user) {
-                const userDoc = await getDoc(doc(db, 'users', user.uid));
-                window.authorName = userDoc.data()?.name || '';
-                window.syncBookAuthor();
-
                 const params = new URLSearchParams(window.location.search);
                 bookCode = params.get('code');
+                bookAuthorUid = params.get('uid') || user.uid;
                 if (!bookCode) {
                     bookCode = `book${Date.now()}`;
                     params.set('code', bookCode);
                     window.history.replaceState({}, '', `${window.location.pathname}?${params}`);
                 }
+
+                const userDoc = await getDoc(doc(db, 'users', bookAuthorUid));
+                window.authorName = userDoc.data()?.name || '';
+                window.syncBookAuthor();
 
                 const bookRef = doc(db, 'Book', bookCode);
                 const bookSnap = await getDoc(bookRef);
@@ -758,6 +760,7 @@
                     } else {
                         await setDoc(bookRef, {
                             author: window.authorName || '',
+                            owner: bookAuthorUid,
                             createdAt: serverTimestamp()
                         });
                         startManualBookCreation();

--- a/public/index.html
+++ b/public/index.html
@@ -4779,7 +4779,7 @@
                     await updateDoc(assignmentRef, { bookCode });
                 }
                 bookCodeDisplay.textContent = bookCode;
-                openBookPageLink.href = `book.html?code=${encodeURIComponent(bookCode)}`;
+                openBookPageLink.href = `book.html?code=${encodeURIComponent(bookCode)}&uid=${encodeURIComponent(dataToShow.id)}`;
 
                 try {
                     const bookRef = doc(db, 'Book', bookCode);
@@ -4795,6 +4795,7 @@
                 } catch (error) {
                     console.error('Error initializing book document:', error);
                     showModal('오류', '책 정보를 생성하는 중 오류가 발생했습니다.');
+                    return;
                 }
 
                 bookActivityModal.style.display = 'flex';


### PR DESCRIPTION
## Summary
- Include student UID in book activity link and store book owner in Firestore
- Prevent overlapping popups when book initialization fails
- Support UID parameter in book page to show correct author name

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c0c3879a7c832e96caf8699b73810a