### PR TITLE
Fix Firestore permissions when creating books

### DIFF
--- a/public/book.html
+++ b/public/book.html
@@ -901,6 +901,7 @@
                 const newBookCode = `book${Date.now()}`;
                 await setDoc(doc(db, 'Book', newBookCode), {
                     author: window.authorName || '',
+                    authorId: bookAuthorUid,
                     owner: bookAuthorUid,
                     createdAt: serverTimestamp(),
                     title


### PR DESCRIPTION
## Summary
- include `authorId` when saving new books so the Firestore rules allow access

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c0fd15c298832e80da329bb8cb40f2