### PR TITLE
Fix title sync on book cover load

### DIFF
--- a/public/book.html
+++ b/public/book.html
@@ -203,7 +203,9 @@
                 addManualPage();
             }
 
-            document.querySelector('#spread-0 .book-title-sync').textContent = data.title || '';
+            document.querySelectorAll('#spread-0 .book-title-sync').forEach(el => {
+                el.textContent = data.title || '';
+            });
             window.authorName = data.author || window.authorName;
             window.syncBookAuthor();
 


### PR DESCRIPTION
## Summary
- Ensure both cover titles update when loading a saved book

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c1089e6964832e8670fb1a4050f02e