### PR TITLE
fix: remove unsupported image response format

### DIFF
--- a/netlify/functions/gpt-handler.js
+++ b/netlify/functions/gpt-handler.js
@@ -23,7 +23,6 @@ exports.handler = async (event) => {
         model: 'gpt-image-1',
         prompt,
         size: '1024x1024',
-        response_format: 'b64_json',
         format: 'webp'
       })
     });


### PR DESCRIPTION
## Summary
- remove unsupported `response_format` parameter from image generation handler

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c18fca6d5c832e9a704d2e2922756c