### PR TITLE
Automatically open library books from index

### DIFF
--- a/public/book.html
+++ b/public/book.html
@@ -1895,6 +1895,8 @@
                 const params = new URLSearchParams(window.location.search);
                 const initialBook = params.get('bookId');
                 if (initialBook) {
+                    // 사용자가 에이두 도서관에서 선택한 책을 바로 볼 수 있도록
+                    libraryTab.click();
                     await loadBook(initialBook);
                 }
             } else {


### PR DESCRIPTION
## Summary
- Ensure `book.html` auto-loads a specific library book when `bookId` query param is provided.
- Programmatically activate the library tab and display the requested book, removing extra user clicks.

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c511c555cc832eaa3cf447729f1c3b