### PR TITLE
Adjust sketchbook button placement

### DIFF
--- a/public/Sketch.html
+++ b/public/Sketch.html
@@ -105,7 +105,7 @@
                             {/* 로고 */}
                             <div className="flex items-center space-x-2">
                                 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="text-blue-500"><path d="M17 3a2.828 2.828 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5L17 3z"></path></svg>
-                                <span className="font-bold text-lg text-gray-800">에이두 스케치</span>
+                                <span className="font-bold text-lg text-gray-800">에이두 스케치북</span>
                             </div>
 
                             {/* 버튼들 */}

--- a/public/index.html
+++ b/public/index.html
@@ -340,7 +340,7 @@
                 <div id="library-book-list" class="flex items-center gap-2 overflow-x-auto"></div>
             </div>
             <div id="sketchbook-tab-content" class="tab-content">
-                <div class="flex items-end justify-end h-[80vh]">
+                <div class="flex items-start justify-end h-[80vh] p-4">
                     <button id="open-sketchbook-btn" class="btn btn-primary">에이두 스케치북 이동</button>
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- Move sketchbook button to the top-right of its tab
- Rename Sketch page header to "에이두 스케치북"

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c5184ddb1c832e9bb1aa06a9af971d