### PR TITLE
Fix Excalidraw file loading in Sketch page

### DIFF
--- a/public/Sketch.html
+++ b/public/Sketch.html
@@ -81,13 +81,15 @@
                             try {
                                 const data = JSON.parse(e.target.result);
                                 if (excalidrawAPI && data.elements && data.appState) {
-                                    // 이미지 등의 파일이 포함되어 있다면 먼저 추가
-                                    if (data.files) {
-                                        excalidrawAPI.addFiles(data.files);
+                                    // 파일 정보는 객체 형태로 저장되므로 Map으로 변환 후 추가
+                                    const files = data.files ? new Map(Object.entries(data.files)) : null;
+                                    if (files) {
+                                        excalidrawAPI.addFiles(files);
                                     }
                                     excalidrawAPI.updateScene({
                                         elements: data.elements,
                                         appState: data.appState,
+                                        ...(files ? { files } : {}),
                                         commitToHistory: true,
                                     });
                                 } else {


### PR DESCRIPTION
## Summary
- convert loaded Excalidraw file metadata to Map before adding to API
- pass file info when updating scene to avoid runtime errors

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c523f96088832e8627b95e6c373116