### PR TITLE
fix: restore collaborators Map during sketch import

### DIFF
--- a/public/Sketch.html
+++ b/public/Sketch.html
@@ -86,10 +86,16 @@
                                     if (files) {
                                         excalidrawAPI.addFiles(files);
                                     }
+                                    // collaborators는 Map 구조여야 하므로 JSON 데이터를 Map으로 변환
+                                    const appState = {
+                                        ...data.appState,
+                                        collaborators: new Map(
+                                            Object.entries(data.appState.collaborators || {})
+                                        ),
+                                    };
                                     excalidrawAPI.updateScene({
                                         elements: data.elements,
-                                        appState: data.appState,
-                                        ...(files ? { files } : {}),
+                                        appState,
                                         commitToHistory: true,
                                     });
                                 } else {


### PR DESCRIPTION
## Summary
- ensure Excalidraw collaborators field is deserialized as a Map
- simplify scene update when importing sketch files

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c52565efa0832e85399f5dfc4931f0