### PR TITLE
feat: integrate sketchbook with cloud storage

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -340,8 +340,12 @@
                 <div id="library-book-list" class="flex items-center gap-2 overflow-x-auto"></div>
             </div>
             <div id="sketchbook-tab-content" class="tab-content">
-                <div class="flex items-start justify-end h-[80vh] p-4">
-                    <button id="open-sketchbook-btn" class="btn btn-primary">에이두 스케치북 이동</button>
+                <div class="p-4 h-[80vh] flex flex-col">
+                    <div class="flex justify-between items-center mb-4">
+                        <h2 class="text-2xl font-bold">🎨 에이두 스케치북</h2>
+                        <button id="create-sketch-btn" class="btn btn-primary">스케치북 만들기</button>
+                    </div>
+                    <ul id="sketchbook-list" class="space-y-2 overflow-y-auto"></ul>
                 </div>
             </div>
             <div id="reading-log-tab-content" class="tab-content">
@@ -1243,14 +1247,39 @@
                     renderReadingLog();
                 } else if (tab.dataset.tab === 'library') {
                     loadLibraryBooks();
+                } else if (tab.dataset.tab === 'sketchbook') {
+                    renderSketchbookList();
                 }
             });
         });
 
-        const openSketchbookBtn = document.getElementById('open-sketchbook-btn');
-        if (openSketchbookBtn) {
-            openSketchbookBtn.addEventListener('click', () => {
-                window.location.href = 'Sketch.html';
+        const createSketchBtn = document.getElementById('create-sketch-btn');
+        const sketchbookListEl = document.getElementById('sketchbook-list');
+
+        async function renderSketchbookList() {
+            if (!currentAuthUser || !sketchbookListEl) return;
+            const snap = await getDocs(collection(db, 'users', currentAuthUser.uid, 'sketches'));
+            sketchbookListEl.innerHTML = '';
+            snap.forEach(docSnap => {
+                const li = document.createElement('li');
+                li.className = 'p-2 bg-white rounded shadow cursor-pointer';
+                li.textContent = docSnap.data().name || '새 스케치북';
+                li.addEventListener('click', () => {
+                    window.open(`sketch.html?sketchId=${docSnap.id}`, '_blank');
+                });
+                sketchbookListEl.appendChild(li);
+            });
+        }
+
+        if (createSketchBtn) {
+            createSketchBtn.addEventListener('click', async () => {
+                if (!currentAuthUser) return;
+                const docRef = await addDoc(collection(db, 'users', currentAuthUser.uid, 'sketches'), {
+                    name: '새 스케치북',
+                    createdAt: serverTimestamp()
+                });
+                await renderSketchbookList();
+                window.open(`sketch.html?sketchId=${docRef.id}`, '_blank');
             });
         }
         document.querySelectorAll('.admin-tab').forEach(tab => {

--- a/public/sketch.html
+++ b/public/sketch.html
@@ -41,37 +41,83 @@
 <body>
     <div id="root"></div>
 
-    <script type="text/babel">
-        // 페이지의 모든 리소스(Excalidraw 스크립트 포함)가 로드된 후 React 앱을 렌더링합니다.
+    <script type="text/babel" data-type="module">
+        import { initializeApp } from "https://www.gstatic.com/firebasejs/11.6.1/firebase-app.js";
+        import { getAuth, onAuthStateChanged } from "https://www.gstatic.com/firebasejs/11.6.1/firebase-auth.js";
+        import { getFirestore, collection, addDoc, getDocs, serverTimestamp } from "https://www.gstatic.com/firebasejs/11.6.1/firebase-firestore.js";
+        import { getStorage, ref as storageRef, uploadBytes, getDownloadURL } from "https://www.gstatic.com/firebasejs/11.6.1/firebase-storage.js";
+
+        const firebaseConfig = {
+            apiKey: "AIzaSyDCeJPDQUNi-KmJ9DhkTRIu-9t2PGZCpt0",
+            authDomain: "mansungcoin-c6e06.firebaseapp.com",
+            projectId: "mansungcoin-c6e06",
+            storageBucket: "mansungcoin-c6e06.firebasestorage.app",
+            messagingSenderId: "704809284946",
+            appId: "1:704809284946:web:3e71d98f38810577e1768b"
+        };
+        const app = initializeApp(firebaseConfig);
+        const auth = getAuth(app);
+        const db = getFirestore(app);
+        const storage = getStorage(app);
+
         window.addEventListener('load', () => {
             const Excalidraw = window.ExcalidrawLib.Excalidraw;
 
             function App() {
                 const [excalidrawAPI, setExcalidrawAPI] = React.useState(null);
+                const [user, setUser] = React.useState(null);
+                const [sketches, setSketches] = React.useState([]);
+                const [currentSketchId, setCurrentSketchId] = React.useState(new URLSearchParams(window.location.search).get('sketchId'));
 
-                // 파일 저장 함수
-                const handleSaveToFile = () => {
-                    if (!excalidrawAPI) return;
+                React.useEffect(() => {
+                    const unsub = onAuthStateChanged(auth, async (u) => {
+                        setUser(u);
+                        if (u) {
+                            const snap = await getDocs(collection(db, 'users', u.uid, 'sketches'));
+                            setSketches(snap.docs.map(d => ({ id: d.id, ...d.data() })));
+                        }
+                    });
+                    return () => unsub();
+                }, []);
+
+                React.useEffect(() => {
+                    if (user && excalidrawAPI && currentSketchId) {
+                        (async () => {
+                            try {
+                                const fileRef = storageRef(storage, `sketches/${user.uid}/${currentSketchId}.excalidraw`);
+                                const url = await getDownloadURL(fileRef);
+                                const res = await fetch(url);
+                                const data = await res.json();
+                                const files = data.files ? new Map(Object.entries(data.files)) : null;
+                                if (files) excalidrawAPI.addFiles(files);
+                                const appState = {
+                                    ...data.appState,
+                                    collaborators: new Map(Object.entries(data.appState?.collaborators || {}))
+                                };
+                                excalidrawAPI.updateScene({ elements: data.elements, appState, commitToHistory: true });
+                            } catch (e) {
+                                console.log('새 스케치북입니다.', e);
+                            }
+                        })();
+                    }
+                }, [user, excalidrawAPI, currentSketchId]);
+
+                const handleSave = async () => {
+                    if (!excalidrawAPI || !user || !currentSketchId) return;
                     const elements = excalidrawAPI.getSceneElements();
                     const appState = excalidrawAPI.getAppState();
                     const data = JSON.stringify({
-                        type: "excalidraw", version: 2, source: "https://gemini.google.com",
-                        elements: elements, appState: appState,
+                        type: 'excalidraw', version: 2, source: 'https://gemini.google.com',
+                        elements, appState,
                     }, null, 2);
-                    const blob = new Blob([data], { type: 'application/json' });
-                    const url = URL.createObjectURL(blob);
-                    const a = document.createElement('a');
-                    a.href = url;
-                    a.download = `drawing-${Date.now()}.excalidraw`;
-                    a.click();
-                    URL.revokeObjectURL(url);
+                    const fileRef = storageRef(storage, `sketches/${user.uid}/${currentSketchId}.excalidraw`);
+                    await uploadBytes(fileRef, new Blob([data], { type: 'application/json' }));
+                    alert('저장되었습니다.');
                 };
 
-                // 파일 불러오기 함수
                 const handleLoadFromFile = () => {
                     const input = document.createElement('input');
                     input.type = 'file';
-                    // Excalidraw 또는 JSON 포맷의 파일만 선택하도록 제한
                     input.accept = ".excalidraw,.json";
                     input.onchange = (event) => {
                         const file = event.target.files[0];
@@ -81,12 +127,10 @@
                             try {
                                 const data = JSON.parse(e.target.result);
                                 if (excalidrawAPI && data.elements && data.appState) {
-                                    // 파일 정보는 객체 형태로 저장되므로 Map으로 변환 후 추가
                                     const files = data.files ? new Map(Object.entries(data.files)) : null;
                                     if (files) {
                                         excalidrawAPI.addFiles(files);
                                     }
-                                    // collaborators는 Map 구조여야 하므로 JSON 데이터를 Map으로 변환
                                     const appState = {
                                         ...data.appState,
                                         collaborators: new Map(
@@ -111,24 +155,35 @@
                     input.click();
                 };
 
+                const handleSelectChange = (e) => {
+                    window.location.href = `sketch.html?sketchId=${e.target.value}`;
+                };
+
+                const handleCreateSketch = async () => {
+                    if (!user) return;
+                    const docRef = await addDoc(collection(db, 'users', user.uid, 'sketches'), {
+                        name: '새 스케치북',
+                        createdAt: serverTimestamp()
+                    });
+                    window.location.href = `sketch.html?sketchId=${docRef.id}`;
+                };
+
                 return (
                     <>
-                        {/* 상단 헤더 영역 */}
                         <header className="flex items-center justify-between p-2 shadow-md bg-white z-10">
-                            {/* 로고 */}
                             <div className="flex items-center space-x-2">
                                 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="text-blue-500"><path d="M17 3a2.828 2.828 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5L17 3z"></path></svg>
                                 <span className="font-bold text-lg text-gray-800">에이두 스케치북</span>
                             </div>
-
-                            {/* 버튼들 */}
                             <div className="flex space-x-2">
-                                <button onClick={handleSaveToFile} className="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded-lg shadow-md transition-all">파일로 저장하기</button>
+                                <select value={currentSketchId || ''} onChange={handleSelectChange} className="border rounded px-2">
+                                    {sketches.map(s => <option key={s.id} value={s.id}>{s.name || '새 스케치북'}</option>)}
+                                </select>
+                                <button onClick={handleCreateSketch} className="bg-green-500 hover:bg-green-700 text-white font-bold py-2 px-3 rounded-lg shadow-md transition-all">스케치북 만들기</button>
+                                <button onClick={handleSave} className="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded-lg shadow-md transition-all">저장하기</button>
                                 <button onClick={handleLoadFromFile} className="bg-gray-500 hover:bg-gray-700 text-white font-bold py-2 px-4 rounded-lg shadow-md transition-all">파일 불러오기</button>
                             </div>
                         </header>
-                        
-                        {/* Excalidraw 캔버스 영역 */}
                         <div className="excalidraw-wrapper">
                             <Excalidraw
                                 excalidrawAPI={(api) => setExcalidrawAPI(api)}

--- a/storage.rules
+++ b/storage.rules
@@ -22,6 +22,11 @@ service firebase.storage {
         );
     }
 
+    // 사용자별 스케치북 파일
+    match /sketches/{userId}/{fileId} {
+      allow read, write: if request.auth != null && request.auth.uid == userId;
+    }
+
     // 그 외 경로: 로그인한 사용자에게만 접근 허용
     match /{allPaths=**} {
       allow read, write: if request.auth != null;


### PR DESCRIPTION
## Summary
- Add sketchbook list and creation in dashboard with Firebase storage-backed entries
- Enable sketch.html to load/save sketches by unique code and manage sketchbook list
- Restrict storage access for sketches to authenticated owners

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c52e5780f8832e8c8e4887d9775a38