### PR TITLE
Add sketchbook management features

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1091,7 +1091,7 @@
         import { getAuth, createUserWithEmailAndPassword, signInWithEmailAndPassword, onAuthStateChanged, signOut, signInAnonymously, signInWithCustomToken, GoogleAuthProvider, signInWithPopup } from "https://www.gstatic.com/firebasejs/11.6.1/firebase-auth.js";
         import { getFirestore, doc, getDoc, setDoc, collection, query, where, getDocs, runTransaction, updateDoc, increment, deleteField, serverTimestamp, Timestamp, orderBy, addDoc, deleteDoc, arrayUnion } from "https://www.gstatic.com/firebasejs/11.6.1/firebase-firestore.js";
         import { getFunctions, httpsCallable } from "https://www.gstatic.com/firebasejs/11.6.1/firebase-functions.js";
-        import { getStorage, ref as storageRef, getDownloadURL } from "https://www.gstatic.com/firebasejs/11.6.1/firebase-storage.js";
+        import { getStorage, ref as storageRef, getDownloadURL, deleteObject } from "https://www.gstatic.com/firebasejs/11.6.1/firebase-storage.js";
 
         // IMPORTANT: Replace with your actual Firebase config
         const firebaseConfig = {
@@ -1262,11 +1262,51 @@
             sketchbookListEl.innerHTML = '';
             snap.forEach(docSnap => {
                 const li = document.createElement('li');
-                li.className = 'p-2 bg-white rounded shadow cursor-pointer';
-                li.textContent = docSnap.data().name || '새 스케치북';
-                li.addEventListener('click', () => {
+                li.className = 'p-2 bg-white rounded shadow flex justify-between items-center';
+
+                const nameSpan = document.createElement('span');
+                nameSpan.className = 'flex-1 cursor-pointer';
+                nameSpan.textContent = docSnap.data().name || '새 스케치북';
+                nameSpan.addEventListener('click', () => {
                     window.open(`sketch.html?sketchId=${docSnap.id}`, '_blank');
                 });
+                li.appendChild(nameSpan);
+
+                const btnContainer = document.createElement('div');
+                btnContainer.className = 'flex space-x-2';
+
+                const renameBtn = document.createElement('button');
+                renameBtn.className = 'text-blue-500';
+                renameBtn.textContent = '이름 변경';
+                renameBtn.addEventListener('click', async (e) => {
+                    e.stopPropagation();
+                    const newName = prompt('새 이름을 입력하세요', nameSpan.textContent);
+                    if (newName) {
+                        await updateDoc(doc(db, 'users', currentAuthUser.uid, 'sketches', docSnap.id), { name: newName });
+                        renderSketchbookList();
+                    }
+                });
+                btnContainer.appendChild(renameBtn);
+
+                const deleteBtn = document.createElement('button');
+                deleteBtn.className = 'text-red-500';
+                deleteBtn.textContent = '삭제';
+                deleteBtn.addEventListener('click', async (e) => {
+                    e.stopPropagation();
+                    if (confirm('정말 삭제하시겠습니까?')) {
+                        await deleteDoc(doc(db, 'users', currentAuthUser.uid, 'sketches', docSnap.id));
+                        try {
+                            await deleteObject(storageRef(storage, `sketches/${currentAuthUser.uid}/${docSnap.id}.excalidraw`));
+                        } catch (err) {
+                            console.error(err);
+                        }
+                        renderSketchbookList();
+                    }
+                });
+                btnContainer.appendChild(deleteBtn);
+
+                li.appendChild(btnContainer);
+
                 sketchbookListEl.appendChild(li);
             });
         }

--- a/public/sketch.html
+++ b/public/sketch.html
@@ -44,8 +44,8 @@
     <script type="text/babel" data-type="module">
         import { initializeApp } from "https://www.gstatic.com/firebasejs/11.6.1/firebase-app.js";
         import { getAuth, onAuthStateChanged } from "https://www.gstatic.com/firebasejs/11.6.1/firebase-auth.js";
-        import { getFirestore, collection, addDoc, getDocs, serverTimestamp } from "https://www.gstatic.com/firebasejs/11.6.1/firebase-firestore.js";
-        import { getStorage, ref as storageRef, uploadBytes, getDownloadURL } from "https://www.gstatic.com/firebasejs/11.6.1/firebase-storage.js";
+        import { getFirestore, collection, addDoc, getDocs, serverTimestamp, doc, updateDoc, deleteDoc } from "https://www.gstatic.com/firebasejs/11.6.1/firebase-firestore.js";
+        import { getStorage, ref as storageRef, uploadBytes, getDownloadURL, deleteObject } from "https://www.gstatic.com/firebasejs/11.6.1/firebase-storage.js";
 
         const firebaseConfig = {
             apiKey: "AIzaSyDCeJPDQUNi-KmJ9DhkTRIu-9t2PGZCpt0",
@@ -168,6 +168,33 @@
                     window.location.href = `sketch.html?sketchId=${docRef.id}`;
                 };
 
+                const handleRenameSketch = async () => {
+                    if (!user || !currentSketchId) return;
+                    const current = sketches.find(s => s.id === currentSketchId);
+                    const newName = prompt('새 이름을 입력하세요', current?.name || '새 스케치북');
+                    if (newName) {
+                        await updateDoc(doc(db, 'users', user.uid, 'sketches', currentSketchId), { name: newName });
+                        setSketches(sketches.map(s => s.id === currentSketchId ? { ...s, name: newName } : s));
+                    }
+                };
+
+                const handleDeleteSketch = async () => {
+                    if (!user || !currentSketchId) return;
+                    if (!confirm('정말 삭제하시겠습니까?')) return;
+                    await deleteDoc(doc(db, 'users', user.uid, 'sketches', currentSketchId));
+                    try {
+                        await deleteObject(storageRef(storage, `sketches/${user.uid}/${currentSketchId}.excalidraw`));
+                    } catch (e) {
+                        console.error(e);
+                    }
+                    const remaining = sketches.filter(s => s.id !== currentSketchId);
+                    if (remaining.length > 0) {
+                        window.location.href = `sketch.html?sketchId=${remaining[0].id}`;
+                    } else {
+                        window.location.href = 'index.html';
+                    }
+                };
+
                 return (
                     <>
                         <header className="flex items-center justify-between p-2 shadow-md bg-white z-10">
@@ -180,6 +207,8 @@
                                     {sketches.map(s => <option key={s.id} value={s.id}>{s.name || '새 스케치북'}</option>)}
                                 </select>
                                 <button onClick={handleCreateSketch} className="bg-green-500 hover:bg-green-700 text-white font-bold py-2 px-3 rounded-lg shadow-md transition-all">스케치북 만들기</button>
+                                <button onClick={handleRenameSketch} className="bg-yellow-500 hover:bg-yellow-700 text-white font-bold py-2 px-3 rounded-lg shadow-md transition-all">이름 변경</button>
+                                <button onClick={handleDeleteSketch} className="bg-red-500 hover:bg-red-700 text-white font-bold py-2 px-3 rounded-lg shadow-md transition-all">삭제</button>
                                 <button onClick={handleSave} className="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded-lg shadow-md transition-all">저장하기</button>
                                 <button onClick={handleLoadFromFile} className="bg-gray-500 hover:bg-gray-700 text-white font-bold py-2 px-4 rounded-lg shadow-md transition-all">파일 불러오기</button>
                             </div>


### PR DESCRIPTION
## Summary
- add options to rename and delete sketchbooks on the dashboard list
- enable renaming and deleting sketches directly within the sketch editor

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c530cd5364832e957c9325cd801b2b