### PR TITLE
Store sketch files per user

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1263,6 +1263,8 @@
             snap.forEach(docSnap => {
                 const li = document.createElement('li');
                 li.className = 'p-2 bg-white rounded shadow flex justify-between items-center';
+                // 각 항목에 스케치 고유 코드를 저장합니다
+                li.dataset.sketchId = docSnap.id;
 
                 const nameSpan = document.createElement('span');
                 nameSpan.className = 'flex-1 cursor-pointer';
@@ -1296,8 +1298,8 @@
                     if (confirm('정말 삭제하시겠습니까?')) {
                         await deleteDoc(doc(db, 'users', currentAuthUser.uid, 'sketches', docSnap.id));
                         try {
-                            // 사용자별 경로 대신 스케치 ID만으로 파일을 삭제합니다
-                            await deleteObject(storageRef(storage, `sketches/${docSnap.id}.excalidraw`));
+                            // 사용자별 경로를 포함하여 파일을 삭제합니다
+                            await deleteObject(storageRef(storage, `sketch/${currentAuthUser.uid}/${docSnap.id}.excalidraw`));
                         } catch (err) {
                             console.error(err);
                         }

--- a/public/sketch.html
+++ b/public/sketch.html
@@ -84,8 +84,8 @@
                     if (user && excalidrawAPI && currentSketchId) {
                         (async () => {
                             try {
-                                // 사용자별 경로 대신 스케치 ID만으로 파일을 로드합니다
-                                const fileRef = storageRef(storage, `sketches/${currentSketchId}.excalidraw`);
+                                // 사용자별 경로를 포함하여 파일을 로드합니다
+                                const fileRef = storageRef(storage, `sketch/${user.uid}/${currentSketchId}.excalidraw`);
                                 const blob = await getBlob(fileRef);
                                 const text = await blob.text();
                                 const data = JSON.parse(text);
@@ -111,8 +111,8 @@
                         type: 'excalidraw', version: 2, source: 'https://gemini.google.com',
                         elements, appState,
                     }, null, 2);
-                    // 사용자별 경로 대신 스케치 ID만으로 파일을 저장합니다
-                    const fileRef = storageRef(storage, `sketches/${currentSketchId}.excalidraw`);
+                    // 사용자별 경로를 포함하여 파일을 저장합니다
+                    const fileRef = storageRef(storage, `sketch/${user.uid}/${currentSketchId}.excalidraw`);
                     await uploadBytes(fileRef, new Blob([data], { type: 'application/json' }));
                     alert('저장되었습니다.');
                 };
@@ -185,8 +185,8 @@
                     if (!confirm('정말 삭제하시겠습니까?')) return;
                     await deleteDoc(doc(db, 'users', user.uid, 'sketches', currentSketchId));
                     try {
-                        // 사용자별 경로 대신 스케치 ID만으로 파일을 삭제합니다
-                        await deleteObject(storageRef(storage, `sketches/${currentSketchId}.excalidraw`));
+                        // 사용자별 경로를 포함하여 파일을 삭제합니다
+                        await deleteObject(storageRef(storage, `sketch/${user.uid}/${currentSketchId}.excalidraw`));
                     } catch (e) {
                         console.error(e);
                     }


### PR DESCRIPTION
## Summary
- Tag each sketch list item with its unique ID on the dashboard
- Save and manage sketch files under per-user folders in storage

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c539d0dff8832eb157272e2a3762c0