### PR TITLE
Fix teacher class management permissions in Firestore rules

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -69,6 +69,16 @@ service cloud.firestore {
         allow read, write:
           if request.auth.uid == userId || isTeacher();
       }
+
+      // ✨ [에이두 스페셜] 학급 관리
+      match /classes/{classId} {
+        allow read, write: if request.auth.uid == userId && isTeacher();
+      }
+
+      // ✨ [에이두 스페셜] 개별화교육계획(IEP)
+      match /ieps/{iepId} {
+        allow read, write: if request.auth.uid == userId && isTeacher();
+      }
     }
 
     // ──────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- allow teachers to read and write their class documents under `users/{userId}/classes`
- allow teachers to manage IEP records under `users/{userId}/ieps`

## Testing
- `npm test` *(fails: Invalid package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c6ccfc9850832eb85c9e4505083a41