### PR TITLE
Fix JSON parsing error in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "license": "ISC",
   "type": "commonjs",
   "dependencies": {
-    "node-fetch": "^3.3.2"
+    "node-fetch": "^3.3.2",
     "next": "^14.2.3",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"


### PR DESCRIPTION
## Summary
- add missing comma in package.json dependencies to restore valid JSON

## Testing
- `node -e "require('./package.json'); console.log('JSON valid')"`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c6ce358720832ea6966afbdf6b8710