### PR TITLE
Fix nested array error when saving achievement data

### DIFF
--- a/public/special.html
+++ b/public/special.html
@@ -422,12 +422,13 @@
             if (!table) return;
             const rows = table.querySelectorAll('tbody tr');
             const states = Array.from(rows).map(tr => {
-                const arr = [];
+                // Firestore does not support nested arrays, so store each row as an object
+                const rowObj = {};
                 for (let i = 1; i < tr.cells.length; i++) {
                     const btn = tr.cells[i].querySelector('button');
-                    arr.push(parseInt(btn.dataset.state || '0'));
+                    rowObj[i - 1] = parseInt(btn.dataset.state || '0');
                 }
-                return arr;
+                return rowObj;
             });
             const key = `${getActiveValue(levelButtons)}_${getActiveValue(subjectButtons)}`;
             currentAchievementData[key] = states;


### PR DESCRIPTION
## Summary
- avoid Firestore nested arrays by storing achievement rows as objects

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c6e47bd1cc832eba49cfda1d68040c