### PR TITLE
Allow superteacher role to access teacher features

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -10,7 +10,7 @@ service cloud.firestore {
 
     function isTeacher() {
       return request.auth != null &&
-             ['teacher', 'superTeacher'].has(
+             ['teacher', 'superTeacher', 'superteacher'].has(
                get(/databases/$(database)/documents/users/$(request.auth.uid)).data.role
              );
     }

--- a/public/book.html
+++ b/public/book.html
@@ -289,7 +289,14 @@
         let canEditBook = false;
         let bookIsPublic = false;
         let imagesGenerated = false;
-        const hasTeacherRole = (role) => role === 'teacher' || role === 'superTeacher';
+        const normalizeRole = (role) => typeof role === 'string' ? role.toLowerCase() : '';
+        const hasTeacherRole = (role) => {
+            if (role === 'superTeacher') {
+                return true;
+            }
+            const normalized = normalizeRole(role);
+            return normalized === 'teacher' || normalized === 'superteacher';
+        };
         const isSuperTeacher = (role) => role === 'superTeacher';
         // 로그인한 사용자 이름을 저장하고 책의 저자 영역을 동기화합니다.
         window.authorName = '';
@@ -622,7 +629,7 @@
             const teacherRequestBtn = document.getElementById('book-teacher-request-btn');
             if (hasTeacherRole(data.role)) {
                 roleBadgeEl.classList.remove('hidden');
-                roleBadgeEl.textContent = data.role === 'superTeacher' ? '슈퍼 관리자' : '교사';
+                roleBadgeEl.textContent = isSuperTeacher(data.role) ? '슈퍼 관리자' : '교사';
                 myClassBtn.classList.remove('hidden');
                 tokenGiveBtn.classList.remove('hidden');
             } else {

--- a/public/index.html
+++ b/public/index.html
@@ -1165,7 +1165,14 @@
         let currentWordChainProblem = null; // 현재 끝말잇기 문제 템플릿
         let isLibraryLoading = false;
 
-        const hasTeacherRole = (role) => role === 'teacher' || role === 'superTeacher';
+        const normalizeRole = (role) => typeof role === 'string' ? role.toLowerCase() : '';
+        const hasTeacherRole = (role) => {
+            if (role === 'superTeacher') {
+                return true;
+            }
+            const normalized = normalizeRole(role);
+            return normalized === 'teacher' || normalized === 'superteacher';
+        };
         const isSuperTeacher = (role) => role === 'superTeacher';
 
         // --- DOM Elements ---
@@ -1530,7 +1537,7 @@
 
             const readingLogFilterBtn = document.getElementById('reading-log-filter-btn');
             if (readingLogFilterBtn) {
-                const canFilter = role === 'teacher';
+                const canFilter = hasTeacherRole(role);
                 readingLogFilterBtn.classList.toggle('hidden', !canFilter);
                 if (!canFilter) {
                     showOnlyMyClassReadingLogs = false;
@@ -1544,7 +1551,7 @@
 
 
             if (hasTeacherRole(role)) {
-                if (role === 'superTeacher') {
+                if (isSuperTeacher(role)) {
                     titleEl.textContent = `${dataToShow.name || '슈퍼 관리자'} 슈퍼 관리자 대시보드`;
                 } else {
                     titleEl.textContent = `${dataToShow.name || '교사'} 대시보드`;
@@ -2234,7 +2241,7 @@
 
                 let classStudentSet = new Set();
                 const superTeacher = isSuperTeacher(currentUserData?.role);
-                if (!superTeacher && currentUserData?.role === 'teacher') {
+                if (!superTeacher && hasTeacherRole(currentUserData?.role)) {
                     const classIds = await ensureMyClassStudentIds();
                     classStudentSet = new Set(classIds);
                 }
@@ -2255,7 +2262,7 @@
                     teachers.forEach(teacher => {
                         const li = document.createElement('li');
                         li.className = 'flex justify-between items-center py-2 border-b';
-                        const isTeacherSuper = teacher.role === 'superTeacher';
+                        const isTeacherSuper = isSuperTeacher(teacher.role);
                         const badgeClasses = isTeacherSuper ? 'bg-purple-100 text-purple-800' : 'bg-red-100 text-red-800';
                         const badgeLabel = isTeacherSuper ? '슈퍼 관리자' : '교사';
                         const actions = [];
@@ -5348,7 +5355,7 @@
                 const qSnap = await getDocs(query(collection(db, 'readingLogs'), orderBy('createdAt', 'desc')));
                 let entries = qSnap.docs.map(docSnap => ({ id: docSnap.id, ...docSnap.data() }));
 
-                if (showOnlyMyClassReadingLogs && currentUserData?.role === 'teacher') {
+                if (showOnlyMyClassReadingLogs && hasTeacherRole(currentUserData?.role)) {
                     if (!myClassStudentIds.length) {
                         const classSnap = await getDoc(doc(db, 'classes', currentUserData.id));
                         myClassStudentIds = classSnap.exists() ? classSnap.data().students || [] : [];
@@ -5390,7 +5397,7 @@
                     rightContainer.className = 'flex items-center ml-2 space-x-2';
                     rightContainer.appendChild(info);
 
-                    if (currentUserData?.role === 'teacher') {
+                    if (hasTeacherRole(currentUserData?.role)) {
                         const delBtn = document.createElement('button');
                         delBtn.textContent = '삭제';
                         delBtn.className = 'text-red-500 text-sm';

--- a/storage.rules
+++ b/storage.rules
@@ -3,7 +3,9 @@ service firebase.storage {
   match /b/{bucket}/o {
     function isTeacher() {
       return request.auth != null &&
-             firestore.get(/databases/(default)/documents/users/$(request.auth.uid)).data.role == 'teacher';
+             ['teacher', 'superTeacher', 'superteacher'].has(
+               firestore.get(/databases/(default)/documents/users/$(request.auth.uid)).data.role
+             );
     }
 
     // Book 파일: 공개 책은 누구나 읽기 가능, 작성자 또는 교사만 쓰기 가능


### PR DESCRIPTION
## Summary
- treat the new `superteacher` role as having teacher capabilities throughout the dashboard and book creator UI
- adjust Firestore and Storage security helpers so the `superteacher` role is authorized like teachers

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68c8d2ed9ed4832ea2f66d5c7dc0a03c