### PR TITLE
Handle superteacher role case insensitively

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -5,7 +5,9 @@ service cloud.firestore {
     // 교사 역할 확인
     function isSuperTeacher() {
       return request.auth != null &&
-             get(/databases/$(database)/documents/users/$(request.auth.uid)).data.role == 'superTeacher';
+             ['superTeacher', 'superteacher'].has(
+               get(/databases/$(database)/documents/users/$(request.auth.uid)).data.role
+             );
     }
 
     function isTeacher() {

--- a/public/book.html
+++ b/public/book.html
@@ -289,15 +289,12 @@
         let canEditBook = false;
         let bookIsPublic = false;
         let imagesGenerated = false;
-        const normalizeRole = (role) => typeof role === 'string' ? role.toLowerCase() : '';
+        const normalizeRole = (role) => typeof role === 'string' ? role.trim().toLowerCase() : '';
         const hasTeacherRole = (role) => {
-            if (role === 'superTeacher') {
-                return true;
-            }
             const normalized = normalizeRole(role);
             return normalized === 'teacher' || normalized === 'superteacher';
         };
-        const isSuperTeacher = (role) => role === 'superTeacher';
+        const isSuperTeacher = (role) => normalizeRole(role) === 'superteacher';
         // 로그인한 사용자 이름을 저장하고 책의 저자 영역을 동기화합니다.
         window.authorName = '';
         window.syncBookAuthor = function() {

--- a/public/index.html
+++ b/public/index.html
@@ -1165,15 +1165,12 @@
         let currentWordChainProblem = null; // 현재 끝말잇기 문제 템플릿
         let isLibraryLoading = false;
 
-        const normalizeRole = (role) => typeof role === 'string' ? role.toLowerCase() : '';
+        const normalizeRole = (role) => typeof role === 'string' ? role.trim().toLowerCase() : '';
         const hasTeacherRole = (role) => {
-            if (role === 'superTeacher') {
-                return true;
-            }
             const normalized = normalizeRole(role);
             return normalized === 'teacher' || normalized === 'superteacher';
         };
-        const isSuperTeacher = (role) => role === 'superTeacher';
+        const isSuperTeacher = (role) => normalizeRole(role) === 'superteacher';
 
         // --- DOM Elements ---
         const views = {


### PR DESCRIPTION
## Summary
- allow the Firestore super teacher guard to accept either camelCase or lowercase role values
- normalize role handling in the client so super teachers are detected even when the stored value is lowercase

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68c8d7a11d3c832eaa549dfdc730f8e8