### PR TITLE
Fix teacher class access and storage CORS handling

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -9,10 +9,10 @@ service cloud.firestore {
     }
 
     function isTeacher() {
-      return request.auth != null &&
-             ['teacher', 'superTeacher'].has(
-               get(/databases/$(database)/documents/users/$(request.auth.uid)).data.role
-             );
+      return request.auth != null && (
+        get(/databases/$(database)/documents/users/$(request.auth.uid)).data.role == 'teacher' ||
+        get(/databases/$(database)/documents/users/$(request.auth.uid)).data.role == 'superTeacher'
+      );
     }
 
     // ──────────────────────────────────────────────────────────────

--- a/storage-cors.json
+++ b/storage-cors.json
@@ -1,7 +1,7 @@
 [
   {
     "origin": ["https://aiedue.netlify.app"],
-    "method": ["GET", "POST", "PUT", "DELETE", "HEAD"],
+    "method": ["GET", "POST", "PUT", "DELETE", "HEAD", "OPTIONS"],
     "responseHeader": ["Content-Type", "x-goog-resumable", "Authorization"],
     "maxAgeSeconds": 3600
   }

--- a/storage.rules
+++ b/storage.rules
@@ -2,17 +2,21 @@ rules_version = '2';
 service firebase.storage {
   match /b/{bucket}/o {
     function isTeacher() {
-      return request.auth != null &&
-             firestore.get(/databases/(default)/documents/users/$(request.auth.uid)).data.role == 'teacher';
+      return request.auth != null && (
+        firestore.get(/databases/(default)/documents/users/$(request.auth.uid)).data.role == 'teacher' ||
+        firestore.get(/databases/(default)/documents/users/$(request.auth.uid)).data.role == 'superTeacher'
+      );
     }
 
     // Book 파일: 공개 책은 누구나 읽기 가능, 작성자 또는 교사만 쓰기 가능
     match /Book/{bookId}/{allPaths=**} {
-      allow read: if request.auth != null &&
+      allow read: if
+        firestore.get(/databases/(default)/documents/Book/$(bookId)).data.isPublic == true ||
         (
-          firestore.get(/databases/(default)/documents/Book/$(bookId)).data.isPublic == true ||
-          firestore.get(/databases/(default)/documents/Book/$(bookId)).data.authorId == request.auth.uid ||
-          isTeacher()
+          request.auth != null && (
+            firestore.get(/databases/(default)/documents/Book/$(bookId)).data.authorId == request.auth.uid ||
+            isTeacher()
+          )
         );
 
       allow write: if request.auth != null &&


### PR DESCRIPTION
## Summary
- ensure Firestore teacher-role check accepts both teacher and superTeacher roles
- update Firebase Storage rules to allow public books to be fetched without authentication and recognise super teachers
- allow OPTIONS requests in the storage CORS config so browsers can complete preflight requests

## Testing
- not run (configuration-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68c8dd667dbc832eb10490cb867d3ddd