### PR TITLE
Allow public library access and fix storage CORS

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -8,6 +8,12 @@ service cloud.firestore {
              get(/databases/$(database)/documents/users/$(request.auth.uid)).data.role == 'teacher';
     }
 
+    // 학생 역할 확인
+    function isStudent() {
+      return request.auth != null &&
+             get(/databases/$(database)/documents/users/$(request.auth.uid)).data.role == 'student';
+    }
+
     // ──────────────────────────────────────────────────────────────
     // 사용자 정보 및 하위 데이터
     // ──────────────────────────────────────────────────────────────
@@ -94,19 +100,19 @@ service cloud.firestore {
       allow create: if request.auth != null &&
                     request.resource.data.authorId == request.auth.uid;
 
-      // 읽기: 공개 책은 모두, 비공개는 작성자 또는 교사만
+      // 읽기: 공개 책은 교사/학생 모두, 비공개는 작성자 또는 교사만
       allow read: if request.auth != null &&
-                  (resource.data.isPublic == true ||
-                   resource.data.authorId == request.auth.uid || isTeacher());
+                  (resource.data.authorId == request.auth.uid ||
+                   isTeacher() ||
+                   (resource.data.isPublic == true && isStudent()));
 
-      // 수정: 작성자 또는 교사이며, authorId를 변경할 수 없음
+      // 수정: 작성자만 가능하며 authorId를 변경할 수 없음
       // 또한, 좋아요/댓글 수 증가를 위해 likesCount 또는 commentsCount 를
       // +1만큼 증가시키는 업데이트는 모든 인증된 사용자에게 허용
       allow update: if request.auth != null &&
         (
           (resource.data.authorId == request.auth.uid &&
            request.resource.data.authorId == request.auth.uid)
-          || isTeacher()
           || (
             request.resource.data.diff(resource.data).changedKeys().hasOnly(['likesCount']) &&
             request.resource.data.likesCount == resource.data.likesCount + 1
@@ -153,6 +159,12 @@ service cloud.firestore {
           allow create, delete: if request.auth != null && request.auth.uid == userId;
         }
       }
+    }
+
+    // 관리자용 가입 로그
+    match /signupLog/{logId} {
+      allow create: if request.auth != null;
+      allow read: if isTeacher();
     }
 
     // ──────────────────────────────────────────────────────────────

--- a/public/book.html
+++ b/public/book.html
@@ -485,7 +485,7 @@
             bookOwnerUid = data.owner || data.authorId || auth.currentUser.uid;
             bookIsPublic = !!data.isPublic;
             imagesGenerated = !!data.coverImage;
-            canEditBook = auth.currentUser && (auth.currentUser.uid === bookOwnerUid || window.currentUserRole === 'teacher');
+            canEditBook = auth.currentUser && auth.currentUser.uid === bookOwnerUid;
             buildBookViewer();
 
             for (let i = 1; i < (data.characterSpreadCount || 1); i++) {

--- a/storage-cors.json
+++ b/storage-cors.json
@@ -1,7 +1,7 @@
 [
   {
     "origin": ["https://aiedue.netlify.app"],
-    "method": ["GET", "POST", "PUT", "DELETE", "HEAD"],
+    "method": ["GET", "POST", "PUT", "DELETE", "HEAD", "OPTIONS"],
     "responseHeader": ["Content-Type", "x-goog-resumable", "Authorization"],
     "maxAgeSeconds": 3600
   }

--- a/storage.rules
+++ b/storage.rules
@@ -6,20 +6,25 @@ service firebase.storage {
              firestore.get(/databases/(default)/documents/users/$(request.auth.uid)).data.role == 'teacher';
     }
 
-    // Book 파일: 공개 책은 누구나 읽기 가능, 작성자 또는 교사만 쓰기 가능
+    function isStudent() {
+      return request.auth != null &&
+             firestore.get(/databases/(default)/documents/users/$(request.auth.uid)).data.role == 'student';
+    }
+
+    // Book 파일: 공개 책은 교사/학생이 읽기 가능, 작성자만 쓰기 가능
     match /Book/{bookId}/{allPaths=**} {
       allow read: if request.auth != null &&
         (
-          firestore.get(/databases/(default)/documents/Book/$(bookId)).data.isPublic == true ||
           firestore.get(/databases/(default)/documents/Book/$(bookId)).data.authorId == request.auth.uid ||
-          isTeacher()
+          isTeacher() ||
+          (
+            firestore.get(/databases/(default)/documents/Book/$(bookId)).data.isPublic == true &&
+            isStudent()
+          )
         );
 
       allow write: if request.auth != null &&
-        (
-          firestore.get(/databases/(default)/documents/Book/$(bookId)).data.authorId == request.auth.uid ||
-          isTeacher()
-        );
+        firestore.get(/databases/(default)/documents/Book/$(bookId)).data.authorId == request.auth.uid;
     }
 
     // 스케치북 파일 (스케치 ID 기반)


### PR DESCRIPTION
## Summary
- add a student role helper to Firestore rules, let teachers view signup logs, and restrict public book edits to the original author
- gate Storage access on the same roles while keeping public books readable by students
- include OPTIONS in the bucket CORS config and hide the edit controls for non-owners in the book viewer

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c8e2cd1534832ea46ac5dd16f2783c