### PR TITLE
Allow Firebase Storage preflight requests

### DIFF
--- a/storage.rules
+++ b/storage.rules
@@ -13,7 +13,8 @@ service firebase.storage {
 
     // Book 파일: 공개 책은 교사/학생이 읽기 가능, 작성자만 쓰기 가능
     match /Book/{bookId}/{allPaths=**} {
-      allow read: if request.auth != null &&
+      allow read: if request.method == 'OPTIONS' || (
+        request.auth != null &&
         (
           firestore.get(/databases/(default)/documents/Book/$(bookId)).data.authorId == request.auth.uid ||
           isTeacher() ||
@@ -21,7 +22,8 @@ service firebase.storage {
             firestore.get(/databases/(default)/documents/Book/$(bookId)).data.isPublic == true &&
             isStudent()
           )
-        );
+        )
+      );
 
       allow write: if request.auth != null &&
         firestore.get(/databases/(default)/documents/Book/$(bookId)).data.authorId == request.auth.uid;
@@ -29,12 +31,12 @@ service firebase.storage {
 
     // 스케치북 파일 (스케치 ID 기반)
     match /sketches/{fileId} {
-      allow read, write: if request.auth != null;
+      allow read, write: if request.method == 'OPTIONS' || request.auth != null;
     }
 
     // 그 외 경로: 로그인한 사용자에게만 접근 허용
     match /{allPaths=**} {
-      allow read, write: if request.auth != null;
+      allow read, write: if request.method == 'OPTIONS' || request.auth != null;
     }
   }
 }


### PR DESCRIPTION
## Summary
- permit anonymous OPTIONS requests in the Book object rule so CORS preflight checks succeed
- extend OPTIONS allowance to sketches and the global storage rule to prevent similar failures elsewhere

## Testing
- not run (rules update only)


------
https://chatgpt.com/codex/tasks/task_e_68c8e8a07f30832e9403750b553ddc3d