### PR TITLE
Allow unauthenticated CORS preflight requests for storage

### DIFF
--- a/storage.rules
+++ b/storage.rules
@@ -11,18 +11,18 @@ service firebase.storage {
              firestore.get(/databases/(default)/documents/users/$(request.auth.uid)).data.role == 'student';
     }
 
+    function isPreflight() {
+      return request.method == 'OPTIONS';
+    }
+
     // Book 파일: 공개 책은 교사/학생이 읽기 가능, 작성자만 쓰기 가능
     match /Book/{bookId}/{allPaths=**} {
-      allow read: if request.method == 'OPTIONS' || (
-        request.auth != null &&
-        (
-          firestore.get(/databases/(default)/documents/Book/$(bookId)).data.authorId == request.auth.uid ||
-          isTeacher() ||
-          (
-            firestore.get(/databases/(default)/documents/Book/$(bookId)).data.isPublic == true &&
-            isStudent()
-          )
-        )
+      allow read: if isPreflight();
+      allow read: if request.auth != null && (
+        let bookDoc = firestore.get(/databases/(default)/documents/Book/$(bookId));
+        bookDoc.data.authorId == request.auth.uid ||
+        isTeacher() ||
+        (bookDoc.data.isPublic == true && isStudent())
       );
 
       allow write: if request.auth != null &&
@@ -31,12 +31,14 @@ service firebase.storage {
 
     // 스케치북 파일 (스케치 ID 기반)
     match /sketches/{fileId} {
-      allow read, write: if request.method == 'OPTIONS' || request.auth != null;
+      allow read: if isPreflight() || request.auth != null;
+      allow write: if request.auth != null;
     }
 
     // 그 외 경로: 로그인한 사용자에게만 접근 허용
     match /{allPaths=**} {
-      allow read, write: if request.method == 'OPTIONS' || request.auth != null;
+      allow read: if isPreflight() || request.auth != null;
+      allow write: if request.auth != null;
     }
   }
 }


### PR DESCRIPTION
## Summary
- add a helper to detect preflight requests in the storage security rules
- explicitly allow OPTIONS requests for book assets, sketches, and other paths while keeping auth checks for real reads and writes
- keep existing role checks for authenticated access to book files

## Testing
- not run (configuration-only change)


------
https://chatgpt.com/codex/tasks/task_e_68c90303b430832eb0929b6bf7943843