### PR TITLE
Split monthly monthly-plan pages per subject and refresh tables

### DIFF
--- a/public/special.html
+++ b/public/special.html
@@ -50,34 +50,37 @@
             width: 100%;
             border-collapse: collapse;
             table-layout: fixed;
+            font-size: 0.95rem;
         }
         .monthly-plan-table th,
         .monthly-plan-table td {
-            border: 1px solid #d1d5db;
+            border: 1px solid #cbd5e1;
             padding: 0.75rem;
             vertical-align: top;
         }
-        .monthly-plan-table th[colspan="2"] {
-            text-align: center;
-            font-weight: 700;
-        }
-        .monthly-plan-table thead th {
-            background-color: #f1f5f9;
-            font-weight: 700;
-            text-align: center;
-        }
-        .monthly-plan-table thead th:not([colspan="2"]) {
-            width: 50%;
-        }
-        .monthly-plan-table tbody .header-cell {
+        .monthly-plan-table .monthly-plan-title {
             background-color: #e2e8f0;
-            font-weight: 700;
             text-align: center;
-            vertical-align: middle;
+            font-weight: 700;
+            font-size: 1rem;
+        }
+        .monthly-plan-table .monthly-plan-section-header {
+            background-color: #f1f5f9;
+            text-align: center;
+            font-weight: 600;
             width: 50%;
         }
-        .monthly-plan-table tbody .data-cell {
+        .monthly-plan-table .monthly-plan-footer {
+            background-color: #dbeafe;
+            text-align: center;
+            font-weight: 600;
+        }
+        .monthly-plan-table .monthly-plan-empty {
+            height: 80px;
+        }
+        .monthly-plan-table .data-cell {
             width: 50%;
+            line-height: 1.6;
         }
         .iep-pages-wrapper {
             position: relative;
@@ -250,12 +253,17 @@
                                         <option value="page-2">2페이지 (성취 기준 - 국어)</option>
                                         <option value="page-3">3페이지 (성취 기준 - 수학)</option>
                                         <option value="page-4">4페이지 (학기별 교육 목표)</option>
-                                        <option value="page-5" data-month-index="0">5페이지 (월별 교육 목표)</option>
-                                        <option value="page-6" data-month-index="1">6페이지 (월별 교육 목표)</option>
-                                        <option value="page-7" data-month-index="2">7페이지 (월별 교육 목표)</option>
-                                        <option value="page-8" data-month-index="3">8페이지 (월별 교육 목표)</option>
-                                        <option value="page-9" data-month-index="4">9페이지 (월별 교육 목표)</option>
-                                        <option value="page-10" data-role="semester-evaluation">10페이지 (학기 평가)</option>
+                                        <option value="page-5" data-month-index="0" data-subject="korean">5페이지 (월별 교육 목표 - 국어)</option>
+                                        <option value="page-6" data-month-index="0" data-subject="math">6페이지 (월별 교육 목표 - 수학)</option>
+                                        <option value="page-7" data-month-index="1" data-subject="korean">7페이지 (월별 교육 목표 - 국어)</option>
+                                        <option value="page-8" data-month-index="1" data-subject="math">8페이지 (월별 교육 목표 - 수학)</option>
+                                        <option value="page-9" data-month-index="2" data-subject="korean">9페이지 (월별 교육 목표 - 국어)</option>
+                                        <option value="page-10" data-month-index="2" data-subject="math">10페이지 (월별 교육 목표 - 수학)</option>
+                                        <option value="page-11" data-month-index="3" data-subject="korean">11페이지 (월별 교육 목표 - 국어)</option>
+                                        <option value="page-12" data-month-index="3" data-subject="math">12페이지 (월별 교육 목표 - 수학)</option>
+                                        <option value="page-13" data-month-index="4" data-subject="korean">13페이지 (월별 교육 목표 - 국어)</option>
+                                        <option value="page-14" data-month-index="4" data-subject="math">14페이지 (월별 교육 목표 - 수학)</option>
+                                        <option value="page-15" data-role="semester-evaluation">15페이지 (학기 평가)</option>
                                         <option value="all">전체</option>
                                     </select>
                                 </div>
@@ -931,12 +939,17 @@
             'page-2': '2페이지(성취 기준 - 국어)',
             'page-3': '3페이지(성취 기준 - 수학)',
             'page-4': '4페이지(학기별 교육 목표)',
-            'page-5': '5페이지(월별 교육 목표)',
-            'page-6': '6페이지(월별 교육 목표)',
-            'page-7': '7페이지(월별 교육 목표)',
-            'page-8': '8페이지(월별 교육 목표)',
-            'page-9': '9페이지(월별 교육 목표)',
-            'page-10': '10페이지(학기 평가)',
+            'page-5': '5페이지(월별 교육 목표 - 국어)',
+            'page-6': '6페이지(월별 교육 목표 - 수학)',
+            'page-7': '7페이지(월별 교육 목표 - 국어)',
+            'page-8': '8페이지(월별 교육 목표 - 수학)',
+            'page-9': '9페이지(월별 교육 목표 - 국어)',
+            'page-10': '10페이지(월별 교육 목표 - 수학)',
+            'page-11': '11페이지(월별 교육 목표 - 국어)',
+            'page-12': '12페이지(월별 교육 목표 - 수학)',
+            'page-13': '13페이지(월별 교육 목표 - 국어)',
+            'page-14': '14페이지(월별 교육 목표 - 수학)',
+            'page-15': '15페이지(학기 평가)',
             'all': '전체'
         };
 
@@ -945,7 +958,13 @@
             pageDescriptions['page-2'] = '2페이지(성취 기준 - 국어)';
             pageDescriptions['page-3'] = '3페이지(성취 기준 - 수학)';
             pageDescriptions['page-4'] = '4페이지(학기별 교육 목표)';
-            pageDescriptions['page-10'] = '10페이지(학기 평가)';
+            Object.keys(pageDescriptions).forEach(key => {
+                const match = key.match(/^page-(\d+)$/);
+                if (!match) return;
+                if (Number(match[1]) >= 5) {
+                    delete pageDescriptions[key];
+                }
+            });
         }
 
         async function loadIepStudents() {
@@ -1412,7 +1431,7 @@
                     target.classList.add(cls);
                 }
             });
-            ['data-page', 'data-month-index', 'data-first-month', 'data-second-month'].forEach(attr => {
+            ['data-page', 'data-month-index', 'data-first-month', 'data-second-month', 'data-subject'].forEach(attr => {
                 if (source.hasAttribute(attr)) {
                     target.setAttribute(attr, source.getAttribute(attr));
                 }
@@ -1538,26 +1557,28 @@
             const defaultSemester = (month >= 8 || month <= 1) ? 2 : 1;
             const months = getSemesterMonths(defaultSemester);
             const monthlyPages = months.map((info, idx) => {
-                const pageNumber = 5 + idx;
                 const monthDisplay = buildMonthlyDisplayText(info);
-                const subjectHeadingSuffix = monthDisplay ? `${monthDisplay} ` : '';
-                return `
-                <section class="iep-page" data-page="${pageNumber}" data-month-index="${idx}" data-first-month="${info.first}" data-second-month="${info.second}">
+                const monthPrefix = monthDisplay ? `${monthDisplay} ` : '';
+                const basePageNumber = 5 + idx * 2;
+                const firstAttr = info.first ? ` data-first-month="${info.first}"` : '';
+                const secondAttr = info.second ? ` data-second-month="${info.second}"` : '';
+                const buildSubjectPage = (subjectKey, subjectLabel, pageNumber) => `
+                <section class="iep-page" data-page="${pageNumber}" data-month-index="${idx}" data-subject="${subjectKey}"${firstAttr}${secondAttr}>
                     <div class="iep-page-inner">
                         <div class="iep-month-block" data-month-index="${idx}">
-                            <div class="iep-month-subject" data-subject="korean">
-                                ${sectionTitleTable(`3. 월별 교육목표 - ${subjectHeadingSuffix}국어`)}
-                                <div id="monthly-plan-${idx}-korean" class="iep-month-content mt-4 text-sm text-gray-500">월별 계획이 생성되지 않았습니다.</div>
-                            </div>
-                            <div class="iep-month-subject mt-6" data-subject="math">
-                                ${sectionTitleTable(`3. 월별 교육목표 - ${subjectHeadingSuffix}수학`)}
-                                <div id="monthly-plan-${idx}-math" class="iep-month-content mt-4 text-sm text-gray-500">월별 계획이 생성되지 않았습니다.</div>
+                            <div class="iep-month-subject" data-subject="${subjectKey}">
+                                ${sectionTitleTable(`3. 월별 교육목표 - ${monthPrefix}${subjectLabel}`)}
+                                <div id="monthly-plan-${idx}-${subjectKey}" class="iep-month-content mt-4"><p class="text-sm text-gray-500">월별 계획이 생성되지 않았습니다.</p></div>
                             </div>
                         </div>
                     </div>
                 </section>`;
+                return [
+                    buildSubjectPage('korean', '국어', basePageNumber),
+                    buildSubjectPage('math', '수학', basePageNumber + 1)
+                ].join('');
             }).join('');
-            const evaluationPageNumber = 5 + months.length;
+            const evaluationPageNumber = 5 + months.length * 2;
             const semesterEvaluationPage = `
                 <section class="iep-page" data-page="${evaluationPageNumber}" data-semester-evaluation="true">
                     <div class="iep-page-inner">
@@ -1715,47 +1736,67 @@
             const months = Array.isArray(monthsArg) ? monthsArg : getSemesterMonths(currentIepSemester);
             const modifySelect = document.getElementById('iep-modify-target');
             const contentRoot = document.getElementById('iep-content');
+            const subjects = [
+                { key: 'korean', label: '국어' },
+                { key: 'math', label: '수학' }
+            ];
             setBasePageDescriptions();
+            if (modifySelect) {
+                modifySelect.querySelectorAll('option[data-month-index]').forEach(option => option.remove());
+            }
             months.forEach((info, idx) => {
                 const displayText = buildMonthlyDisplayText(info);
-                const pageNumber = 5 + idx;
-                if (modifySelect) {
-                    const option = modifySelect.querySelector(`option[data-month-index="${idx}"]`);
-                    if (option) {
+                const monthPrefix = displayText ? `${displayText} ` : '';
+                subjects.forEach((subject, subjectIdx) => {
+                    const pageNumber = 5 + idx * subjects.length + subjectIdx;
+                    pageDescriptions[`page-${pageNumber}`] = `${pageNumber}페이지(월별 교육 목표 - ${monthPrefix}${subject.label})`;
+                    if (modifySelect) {
+                        const option = document.createElement('option');
+                        option.dataset.monthIndex = idx;
+                        option.dataset.subject = subject.key;
                         option.value = `page-${pageNumber}`;
-                        option.textContent = `${pageNumber}페이지 (월별 교육 목표 - ${displayText})`;
-                    }
-                }
-                pageDescriptions[`page-${pageNumber}`] = `${pageNumber}페이지(월별 교육 목표 - ${displayText})`;
-                if (!contentRoot) return;
-                const monthSection = contentRoot.querySelector(`.iep-page[data-month-index="${idx}"]`);
-                if (!monthSection) return;
-                monthSection.setAttribute('data-page', String(pageNumber));
-                monthSection.setAttribute('data-month-index', String(idx));
-                const block = monthSection.querySelector('.iep-month-block');
-                if (block) {
-                    block.setAttribute('data-month-index', String(idx));
-                }
-                const subjectOrder = ['korean', 'math'];
-                subjectOrder.forEach((subject, subjectIdx) => {
-                    let subjectSection = monthSection.querySelector(`.iep-month-subject[data-subject="${subject}"]`);
-                    if (!subjectSection) {
-                        const fallback = monthSection.querySelectorAll('.iep-month-subject')[subjectIdx];
-                        if (fallback) {
-                            fallback.setAttribute('data-subject', subject);
-                            subjectSection = fallback;
+                        option.textContent = `${pageNumber}페이지 (월별 교육 목표 - ${monthPrefix}${subject.label})`;
+                        const evaluationOption = modifySelect.querySelector('option[data-role="semester-evaluation"]');
+                        const allOption = modifySelect.querySelector('option[value="all"]');
+                        if (evaluationOption) {
+                            modifySelect.insertBefore(option, evaluationOption);
+                        } else if (allOption) {
+                            modifySelect.insertBefore(option, allOption);
+                        } else {
+                            modifySelect.appendChild(option);
                         }
                     }
+                    if (!contentRoot) return;
+                    const selector = `.iep-page[data-month-index="${idx}"][data-subject="${subject.key}"]`;
+                    const monthSection = contentRoot.querySelector(selector);
+                    if (!monthSection) return;
+                    monthSection.setAttribute('data-page', String(pageNumber));
+                    monthSection.setAttribute('data-month-index', String(idx));
+                    monthSection.setAttribute('data-subject', subject.key);
+                    if (info.first) {
+                        monthSection.setAttribute('data-first-month', info.first);
+                    } else {
+                        monthSection.removeAttribute('data-first-month');
+                    }
+                    if (info.second) {
+                        monthSection.setAttribute('data-second-month', info.second);
+                    } else {
+                        monthSection.removeAttribute('data-second-month');
+                    }
+                    const block = monthSection.querySelector('.iep-month-block');
+                    if (block) {
+                        block.setAttribute('data-month-index', String(idx));
+                    }
+                    const subjectSection = monthSection.querySelector('.iep-month-subject');
                     if (subjectSection) {
+                        subjectSection.setAttribute('data-subject', subject.key);
                         const headingStrong = subjectSection.querySelector('table thead th strong');
                         if (headingStrong) {
-                            const subjectLabel = subject === 'math' ? '수학' : '국어';
-                            const monthPrefix = displayText ? `${displayText} ` : '';
-                            headingStrong.textContent = `3. 월별 교육목표 - ${monthPrefix}${subjectLabel}`;
+                            headingStrong.textContent = `3. 월별 교육목표 - ${monthPrefix}${subject.label}`;
                         }
                         const content = subjectSection.querySelector('.iep-month-content');
                         if (content) {
-                            const expectedId = `monthly-plan-${idx}-${subject}`;
+                            const expectedId = `monthly-plan-${idx}-${subject.key}`;
                             if (content.id !== expectedId) {
                                 content.id = expectedId;
                             }
@@ -1763,14 +1804,22 @@
                     }
                 });
             });
-            const evaluationPageNumber = 5 + months.length;
+            const evaluationPageNumber = 5 + months.length * subjects.length;
             pageDescriptions[`page-${evaluationPageNumber}`] = `${evaluationPageNumber}페이지(학기 평가)`;
             if (modifySelect) {
-                const evaluationOption = modifySelect.querySelector('option[data-role="semester-evaluation"]');
-                if (evaluationOption) {
-                    evaluationOption.value = `page-${evaluationPageNumber}`;
-                    evaluationOption.textContent = `${evaluationPageNumber}페이지 (학기 평가)`;
+                let evaluationOption = modifySelect.querySelector('option[data-role="semester-evaluation"]');
+                const allOption = modifySelect.querySelector('option[value="all"]');
+                if (!evaluationOption) {
+                    evaluationOption = document.createElement('option');
+                    evaluationOption.dataset.role = 'semester-evaluation';
+                    if (allOption) {
+                        modifySelect.insertBefore(evaluationOption, allOption);
+                    } else {
+                        modifySelect.appendChild(evaluationOption);
+                    }
                 }
+                evaluationOption.value = `page-${evaluationPageNumber}`;
+                evaluationOption.textContent = `${evaluationPageNumber}페이지 (학기 평가)`;
             }
         }
 
@@ -1810,32 +1859,32 @@
             const method = formatTableCell(entry.method);
             const evaluation = formatTableCell(entry.evaluation || '');
             return `
-                <table class="monthly-plan-table text-sm">
-                    <thead>
-                        <tr>
-                            <th colspan="2" class="text-center">${month} ${subjectName}</th>
-                        </tr>
-                        <tr>
-                            <th class="text-center">교육 목표</th>
-                            <th class="text-center">교육 내용 · 방법 · 월 평가</th>
-                        </tr>
-                    </thead>
+                <table class="monthly-plan-table text-base">
                     <tbody>
+                        <tr>
+                            <th class="monthly-plan-title" colspan="2">${month} ${subjectName}</th>
+                        </tr>
+                        <tr>
+                            <th class="monthly-plan-section-header">교육 목표</th>
+                            <th class="monthly-plan-section-header">교육 내용</th>
+                        </tr>
                         <tr>
                             <td class="data-cell">${goal}</td>
                             <td class="data-cell">${content}</td>
                         </tr>
                         <tr>
-                            <td class="header-cell">교육 방법</td>
-                            <td class="data-cell">${method}</td>
+                            <th class="monthly-plan-section-header">교육 방법</th>
+                            <th class="monthly-plan-section-header">교육 평가</th>
                         </tr>
                         <tr>
-                            <td class="header-cell">월 평가</td>
+                            <td class="data-cell">${method}</td>
                             <td class="data-cell">${evaluation}</td>
                         </tr>
                         <tr>
-                            <td class="header-cell">월 평가 입력</td>
-                            <td class="data-cell">&nbsp;</td>
+                            <th class="monthly-plan-footer" colspan="2">월 평가</th>
+                        </tr>
+                        <tr>
+                            <td class="monthly-plan-empty" colspan="2">&nbsp;</td>
                         </tr>
                     </tbody>
                 </table>


### PR DESCRIPTION
## Summary
- render monthly IEP pages as separate sheets for Korean and Math with updated numbering
- rebuild the monthly plan table markup and styles to match the requested layout
- update supporting UI logic for page descriptions, dropdown options, and evaluation page numbering

## Testing
- not run (no automated tests provided)


------
https://chatgpt.com/codex/tasks/task_e_68cab5279fd0832eaa81353dd1a671da