### PR TITLE
Revamp IEP modification panel and extend monthly evaluation

### DIFF
--- a/public/special.html
+++ b/public/special.html
@@ -46,6 +46,30 @@
             background-color: #f1f5f9; /* slate-100 */
             color: #475569; /* slate-600 */
         }
+        .modify-target-btn {
+            padding: 0.4rem 0.75rem;
+            border-radius: 0.5rem;
+            border: 1px solid #bae6fd;
+            background-color: #f8fafc;
+            color: #0369a1;
+            font-size: 0.875rem;
+            font-weight: 500;
+            transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s;
+        }
+        .modify-target-btn:hover {
+            background-color: #e0f2fe;
+            border-color: #7dd3fc;
+        }
+        .modify-target-btn.active {
+            background-color: #0ea5e9;
+            border-color: #0284c7;
+            color: #ffffff;
+            box-shadow: 0 0 0 2px rgba(14, 165, 233, 0.2);
+        }
+        .manual-editing {
+            outline: 2px dashed #0ea5e9;
+            outline-offset: 4px;
+        }
         .monthly-plan-table {
             width: 100%;
             border-collapse: collapse;
@@ -245,31 +269,24 @@
                                 <!-- 학생 목록이 여기에 표시됩니다. -->
                             </div>
                             <div id="iep-modify-section" class="mt-6 hidden">
+                                <div id="iep-generation-section" class="mb-4 hidden">
+                                    <h4 class="font-semibold mb-2">생성 테이블</h4>
+                                    <div class="flex flex-wrap gap-2">
+                                        <button id="iep-achievement-btn" class="flex-1 min-w-[180px] border border-sky-500 text-sky-600 text-sm font-medium px-3 py-2 rounded transition hover:bg-sky-50">성취 기준 이동</button>
+                                        <button id="generate-semester-goals-btn" class="flex-1 min-w-[180px] border border-sky-500 text-sky-600 text-sm font-medium px-3 py-2 rounded transition hover:bg-sky-50">학기 교육목표 생성</button>
+                                        <button id="generate-monthly-plan-btn" class="flex-1 min-w-[220px] border border-sky-500 text-sky-600 text-sm font-medium px-3 py-2 rounded transition hover:bg-sky-50 hidden">월별 교육목표/내용/방법 생성하기</button>
+                                    </div>
+                                </div>
                                 <h4 class="font-semibold mb-2">수정 테이블</h4>
-                                <div class="mb-2">
-                                    <label for="iep-modify-target" class="text-sm font-medium mr-2">수정 항목</label>
-                                    <select id="iep-modify-target" class="border rounded p-1 text-sm">
-                                        <option value="page-1">1페이지 (표지)</option>
-                                        <option value="page-2">2페이지 (성취 기준 - 국어)</option>
-                                        <option value="page-3">3페이지 (성취 기준 - 수학)</option>
-                                        <option value="page-4">4페이지 (학기별 교육 목표)</option>
-                                        <option value="page-5" data-month-index="0" data-subject="korean">5페이지 (월별 교육 목표 - 국어)</option>
-                                        <option value="page-6" data-month-index="0" data-subject="math">6페이지 (월별 교육 목표 - 수학)</option>
-                                        <option value="page-7" data-month-index="1" data-subject="korean">7페이지 (월별 교육 목표 - 국어)</option>
-                                        <option value="page-8" data-month-index="1" data-subject="math">8페이지 (월별 교육 목표 - 수학)</option>
-                                        <option value="page-9" data-month-index="2" data-subject="korean">9페이지 (월별 교육 목표 - 국어)</option>
-                                        <option value="page-10" data-month-index="2" data-subject="math">10페이지 (월별 교육 목표 - 수학)</option>
-                                        <option value="page-11" data-month-index="3" data-subject="korean">11페이지 (월별 교육 목표 - 국어)</option>
-                                        <option value="page-12" data-month-index="3" data-subject="math">12페이지 (월별 교육 목표 - 수학)</option>
-                                        <option value="page-13" data-month-index="4" data-subject="korean">13페이지 (월별 교육 목표 - 국어)</option>
-                                        <option value="page-14" data-month-index="4" data-subject="math">14페이지 (월별 교육 목표 - 수학)</option>
-                                        <option value="page-15" data-role="semester-evaluation">15페이지 (학기 평가)</option>
-                                        <option value="all">전체</option>
-                                    </select>
+                                <div class="mb-3">
+                                    <div id="iep-modify-targets" class="flex flex-wrap gap-2"></div>
                                 </div>
                                 <div class="flex items-start gap-2">
                                     <textarea id="iep-modify-input" class="w-full border rounded-md p-2 text-sm" rows="3" placeholder="수정할 내용을 입력하세요"></textarea>
                                     <button id="iep-modify-btn" class="bg-sky-600 hover:bg-sky-700 text-white text-sm px-3 py-1 rounded h-9">수정</button>
+                                </div>
+                                <div class="mt-2">
+                                    <button id="iep-manual-edit-btn" class="border border-sky-500 text-sky-600 text-sm font-medium px-3 py-1 rounded transition hover:bg-sky-50">수동 편집</button>
                                 </div>
                             </div>
                         </aside>
@@ -967,6 +984,196 @@
             });
         }
 
+        const modifyInput = document.getElementById('iep-modify-input');
+        const modifyBtn = document.getElementById('iep-modify-btn');
+        const modifyTargetsContainer = document.getElementById('iep-modify-targets');
+        const generationSection = document.getElementById('iep-generation-section');
+        const manualEditBtn = document.getElementById('iep-manual-edit-btn');
+        const achievementButton = document.getElementById('iep-achievement-btn');
+        const generateSemesterBtn = document.getElementById('generate-semester-goals-btn');
+        const generateMonthlyBtn = document.getElementById('generate-monthly-plan-btn');
+        let currentModifyTarget = 'page-1';
+        let manualEditMode = false;
+        let manualEditNode = null;
+
+        function getModifyTargetEntries() {
+            const entries = [
+                { value: 'page-1', label: '표지' },
+                { value: 'page-2', label: '성취기준-국어' },
+                { value: 'page-3', label: '성취기준-수학' },
+                { value: 'page-4', label: '학기 교육목표' }
+            ];
+            const contentRoot = document.getElementById('iep-content');
+            if (contentRoot) {
+                const months = getSemesterMonths(currentIepSemester);
+                const monthlyPages = Array.from(contentRoot.querySelectorAll('.iep-page[data-month-index]'));
+                monthlyPages.sort((a, b) => {
+                    const aPage = Number(a.getAttribute('data-page')) || 0;
+                    const bPage = Number(b.getAttribute('data-page')) || 0;
+                    return aPage - bPage;
+                });
+                monthlyPages.forEach(page => {
+                    const pageValue = page.getAttribute('data-page');
+                    if (!pageValue) return;
+                    const monthIdx = Number(page.getAttribute('data-month-index')) || 0;
+                    const subjectKey = page.getAttribute('data-subject') || 'korean';
+                    const subjectLabel = subjectKey === 'math' ? '수학' : '국어';
+                    const monthLabel = months[monthIdx]?.actual || `${monthIdx + 1}월`;
+                    entries.push({ value: `page-${pageValue}`, label: `월(${monthLabel})-${subjectLabel}` });
+                });
+                const evaluationPage = contentRoot.querySelector('.iep-page[data-semester-evaluation="true"]');
+                if (evaluationPage) {
+                    const evalPageValue = evaluationPage.getAttribute('data-page');
+                    if (evalPageValue) {
+                        entries.push({ value: `page-${evalPageValue}`, label: '학기 평가' });
+                    }
+                }
+            }
+            entries.push({ value: 'all', label: '전체' });
+            const seen = new Set();
+            return entries.filter(entry => {
+                if (!entry.value || seen.has(entry.value)) return false;
+                seen.add(entry.value);
+                return true;
+            });
+        }
+
+        function renderModifyTargetButtons() {
+            if (!modifyTargetsContainer) return;
+            const entries = getModifyTargetEntries();
+            if (!entries.length) {
+                modifyTargetsContainer.innerHTML = '';
+                return;
+            }
+            if (!entries.some(entry => entry.value === currentModifyTarget)) {
+                currentModifyTarget = entries[0].value;
+            }
+            modifyTargetsContainer.innerHTML = '';
+            entries.forEach(entry => {
+                const btn = document.createElement('button');
+                btn.type = 'button';
+                btn.className = 'modify-target-btn';
+                btn.dataset.target = entry.value;
+                btn.textContent = entry.label;
+                if (entry.value === currentModifyTarget) {
+                    btn.classList.add('active');
+                }
+                btn.addEventListener('click', () => handleModifyTargetSelection(entry.value));
+                modifyTargetsContainer.appendChild(btn);
+            });
+        }
+
+        function updateModifyTargetActiveState() {
+            if (!modifyTargetsContainer) return;
+            modifyTargetsContainer.querySelectorAll('button').forEach(btn => {
+                if (btn.dataset.target === currentModifyTarget) {
+                    btn.classList.add('active');
+                } else {
+                    btn.classList.remove('active');
+                }
+            });
+        }
+
+        function handleModifyTargetSelection(value) {
+            if (manualEditMode) {
+                alert('수동 편집을 완료한 후 다른 항목을 선택해 주세요.');
+                return;
+            }
+            currentModifyTarget = value;
+            updateModifyTargetActiveState();
+        }
+
+        function exitManualEditMode(skipSync = false) {
+            if (!manualEditMode) return;
+            if (manualEditNode) {
+                manualEditNode.removeAttribute('contenteditable');
+                manualEditNode.classList.remove('manual-editing');
+            }
+            manualEditMode = false;
+            manualEditNode = null;
+            if (manualEditBtn) manualEditBtn.textContent = '수동 편집';
+            if (modifyBtn) modifyBtn.disabled = false;
+            if (!skipSync) {
+                normalizeIepPages(document.getElementById('iep-content'));
+                updateMonthlyPageDisplays();
+                extractSemesterGoalsFromDom();
+            }
+        }
+
+        function startManualEdit() {
+            if (manualEditMode) return;
+            if (!currentModifyTarget) {
+                alert('수정할 항목을 선택해 주세요.');
+                return;
+            }
+            const contentRoot = document.getElementById('iep-content');
+            if (!contentRoot) {
+                alert('편집할 항목이 없습니다.');
+                return;
+            }
+            let targetNode = null;
+            if (currentModifyTarget === 'all') {
+                targetNode = contentRoot;
+            } else {
+                targetNode = findIepPageNode(currentModifyTarget);
+            }
+            if (!targetNode) {
+                alert('선택한 항목을 찾을 수 없습니다.');
+                return;
+            }
+            const editableNode = currentModifyTarget === 'all'
+                ? targetNode
+                : (targetNode.querySelector('.iep-page-inner') || targetNode);
+            manualEditMode = true;
+            manualEditNode = editableNode;
+            editableNode.setAttribute('contenteditable', 'true');
+            editableNode.classList.add('manual-editing');
+            if (modifyBtn) modifyBtn.disabled = true;
+            if (manualEditBtn) manualEditBtn.textContent = '완료';
+            setTimeout(() => {
+                try {
+                    editableNode.focus();
+                } catch (err) {
+                    console.warn('Unable to focus editable node', err);
+                }
+            }, 0);
+        }
+
+        manualEditBtn?.addEventListener('click', () => {
+            if (manualEditMode) {
+                exitManualEditMode();
+            } else {
+                startManualEdit();
+            }
+        });
+
+        achievementButton?.addEventListener('click', () => {
+            if (manualEditMode) {
+                alert('수동 편집을 완료한 후 이동해 주세요.');
+                return;
+            }
+            if (currentIepStudent) {
+                openAchievementView(currentIepStudent);
+            }
+        });
+
+        generateSemesterBtn?.addEventListener('click', async () => {
+            if (manualEditMode) {
+                alert('수동 편집을 완료한 후 생성 기능을 사용해 주세요.');
+                return;
+            }
+            await generateSemesterGoals(lastKoreanList, lastMathList);
+            generateMonthlyBtn?.classList.remove('hidden');
+        });
+
+        generateMonthlyBtn?.addEventListener('click', async () => {
+            if (manualEditMode) {
+                alert('수동 편집을 완료한 후 생성 기능을 사용해 주세요.');
+                return;
+            }
+            await generateMonthlyPlans(lastKoreanList, lastMathList);
+        });
+
         async function loadIepStudents() {
             const user = auth.currentUser;
             if (!user || isLoadingIepStudents) return;
@@ -1008,11 +1215,23 @@
         }
 
         function showModifySection() {
-            document.getElementById('iep-modify-section').classList.remove('hidden');
+            const section = document.getElementById('iep-modify-section');
+            section?.classList.remove('hidden');
+            generationSection?.classList.remove('hidden');
+            renderModifyTargetButtons();
+            updateModifyTargetActiveState();
         }
 
         function hideModifySection() {
-            document.getElementById('iep-modify-section').classList.add('hidden');
+            const section = document.getElementById('iep-modify-section');
+            section?.classList.add('hidden');
+            generationSection?.classList.add('hidden');
+            generateMonthlyBtn?.classList.add('hidden');
+            exitManualEditMode(true);
+            currentModifyTarget = 'page-1';
+            if (modifyTargetsContainer) {
+                modifyTargetsContainer.innerHTML = '';
+            }
         }
 
         async function showIepList(studentName) {
@@ -1216,17 +1435,15 @@
             updateMonthlyPageDisplays(months);
             extractSemesterGoalsFromDom();
             const monthlyBtn = document.getElementById('generate-monthly-plan-btn');
-            if (monthlyBtn && (lastSemesterGoals.korean.length || lastSemesterGoals.math.length)) {
-                monthlyBtn.classList.remove('hidden');
+            if (monthlyBtn) {
+                if (lastSemesterGoals.korean.length || lastSemesterGoals.math.length) {
+                    monthlyBtn.classList.remove('hidden');
+                } else {
+                    monthlyBtn.classList.add('hidden');
+                }
             }
-            document.getElementById('iep-achievement-btn')?.addEventListener('click', () => openAchievementView(studentName));
-            document.getElementById('generate-semester-goals-btn')?.addEventListener('click', async () => {
-                await generateSemesterGoals(lastKoreanList, lastMathList);
-                document.getElementById('generate-monthly-plan-btn')?.classList.remove('hidden');
-            });
-            document.getElementById('generate-monthly-plan-btn')?.addEventListener('click', async () => {
-                await generateMonthlyPlans(lastKoreanList, lastMathList);
-            });
+            currentModifyTarget = 'page-1';
+            updateModifyTargetActiveState();
             const editBtn = document.getElementById('edit-iep-title');
             editBtn.addEventListener('click', () => {
                 const container = document.getElementById('iep-title');
@@ -1325,15 +1542,15 @@
         }
     }
 
-        const modifyInput = document.getElementById('iep-modify-input');
-        const modifyBtn = document.getElementById('iep-modify-btn');
-        const modifyTarget = document.getElementById('iep-modify-target');
-
         async function applyModification() {
             const instruction = modifyInput.value.trim();
-            const target = modifyTarget.value;
+            if (manualEditMode) {
+                alert('수동 편집을 완료한 후 수정 기능을 사용해 주세요.');
+                return;
+            }
+            const target = currentModifyTarget;
             const contentRoot = document.getElementById('iep-content');
-            if (!instruction || !currentIepDocId || !contentRoot) return;
+            if (!instruction || !currentIepDocId || !contentRoot || !target) return;
 
             modifyInput.value = '';
             const button = modifyBtn;
@@ -1599,9 +1816,6 @@
                 <section class="iep-page" data-page="2">
                     <div class="iep-page-inner">
                         ${sectionTitleTable('1. 학습이 필요한 성취 기준 - 국어')}
-                        <div class="flex justify-end">
-                            <button id="iep-achievement-btn" class="text-sky-600 hover:underline text-sm">성취 기준 이동</button>
-                        </div>
                         <div>
                             <h4 class="font-semibold">국어</h4>
                             ${buildAchievementTable(koreanList)}
@@ -1620,9 +1834,6 @@
                 <section class="iep-page" data-page="4">
                     <div class="iep-page-inner">
                         ${sectionTitleTable('2. 학기별 교육 목표')}
-                        <div class="flex justify-end">
-                            <button id="generate-semester-goals-btn" class="text-sky-600 hover:underline text-sm">생성</button>
-                        </div>
                         <div>
                             <h4 class="font-semibold">가. 국어</h4>
                             <div id="korean-goals"></div>
@@ -1630,9 +1841,6 @@
                         <div>
                             <h4 class="font-semibold">나. 수학</h4>
                             <div id="math-goals"></div>
-                        </div>
-                        <div class="flex justify-end">
-                            <button id="generate-monthly-plan-btn" class="text-sky-600 hover:underline text-sm hidden">월별 교육목표/내용/방법 생성하기</button>
                         </div>
                     </div>
                 </section>
@@ -1734,38 +1942,18 @@
 
         function updateMonthlyPageDisplays(monthsArg) {
             const months = Array.isArray(monthsArg) ? monthsArg : getSemesterMonths(currentIepSemester);
-            const modifySelect = document.getElementById('iep-modify-target');
             const contentRoot = document.getElementById('iep-content');
             const subjects = [
                 { key: 'korean', label: '국어' },
                 { key: 'math', label: '수학' }
             ];
             setBasePageDescriptions();
-            if (modifySelect) {
-                modifySelect.querySelectorAll('option[data-month-index]').forEach(option => option.remove());
-            }
             months.forEach((info, idx) => {
                 const displayText = buildMonthlyDisplayText(info);
                 const monthPrefix = displayText ? `${displayText} ` : '';
                 subjects.forEach((subject, subjectIdx) => {
                     const pageNumber = 5 + idx * subjects.length + subjectIdx;
                     pageDescriptions[`page-${pageNumber}`] = `${pageNumber}페이지(월별 교육 목표 - ${monthPrefix}${subject.label})`;
-                    if (modifySelect) {
-                        const option = document.createElement('option');
-                        option.dataset.monthIndex = idx;
-                        option.dataset.subject = subject.key;
-                        option.value = `page-${pageNumber}`;
-                        option.textContent = `${pageNumber}페이지 (월별 교육 목표 - ${monthPrefix}${subject.label})`;
-                        const evaluationOption = modifySelect.querySelector('option[data-role="semester-evaluation"]');
-                        const allOption = modifySelect.querySelector('option[value="all"]');
-                        if (evaluationOption) {
-                            modifySelect.insertBefore(option, evaluationOption);
-                        } else if (allOption) {
-                            modifySelect.insertBefore(option, allOption);
-                        } else {
-                            modifySelect.appendChild(option);
-                        }
-                    }
                     if (!contentRoot) return;
                     const selector = `.iep-page[data-month-index="${idx}"][data-subject="${subject.key}"]`;
                     const monthSection = contentRoot.querySelector(selector);
@@ -1806,21 +1994,8 @@
             });
             const evaluationPageNumber = 5 + months.length * subjects.length;
             pageDescriptions[`page-${evaluationPageNumber}`] = `${evaluationPageNumber}페이지(학기 평가)`;
-            if (modifySelect) {
-                let evaluationOption = modifySelect.querySelector('option[data-role="semester-evaluation"]');
-                const allOption = modifySelect.querySelector('option[value="all"]');
-                if (!evaluationOption) {
-                    evaluationOption = document.createElement('option');
-                    evaluationOption.dataset.role = 'semester-evaluation';
-                    if (allOption) {
-                        modifySelect.insertBefore(evaluationOption, allOption);
-                    } else {
-                        modifySelect.appendChild(evaluationOption);
-                    }
-                }
-                evaluationOption.value = `page-${evaluationPageNumber}`;
-                evaluationOption.textContent = `${evaluationPageNumber}페이지 (학기 평가)`;
-            }
+            renderModifyTargetButtons();
+            updateModifyTargetActiveState();
         }
 
         function sanitizeFileName(text) {
@@ -1834,7 +2009,7 @@
             const achievementText = subject.list.length
                 ? subject.list.map((item, idx) => `${idx + 1}. ${item.text}`).join('\n')
                 : '관련 성취기준 정보 없음';
-            const prompt = `너는 특수교육 교사를 돕는 전문가야. 아래 정보를 참고하여 ${subject.name} 교과의 월별 계획을 JSON 배열로 작성해줘.\n\n- 학기: ${currentIepSemester}학기\n- 월 목록: ${monthLabels.join(', ')}\n- 학기 교육목표:\n${semesterGoals.map((goal, idx) => `${idx + 1}. ${goal}`).join('\n')}\n- 참고 성취기준:\n${achievementText}\n\n요구사항:\n1. 학기 교육목표의 핵심을 순서대로 ${monthLabels.length}개의 월별 교육목표로 나누어 제시한다. 필요한 경우 문장을 분할하거나 통합하되 모든 학기 목표 내용이 월별 목표에 반영되어야 한다.\n2. 각 월별 계획의 goal, content, method 값은 불릿 포인트 형식의 문자열로 작성한다. 불릿은 반드시 '○ '로 시작하고 문장마다 줄바꿈으로 구분한다.\n3. goal 항목은 2문장 이상, content와 method 항목은 각각 3문장 이상으로 작성한다.\n4. content 항목의 모든 문장은 마침표 없이 '~기' 형태(예: ...하기, ...쓰기)로 끝나도록 작성한다.\n5. 모든 문장은 자연스러운 한국어로 작성한다.\n6. 응답은 반드시 JSON 배열만으로 제공하고 다른 설명은 포함하지 않는다.\n7. 배열의 각 요소는 {"month":"${monthLabels[0]}","goal":"...","content":"...","method":"..."} 형식을 따르며, month 값은 월 목록과 정확히 일치하고 순서를 유지해야 한다.`;
+            const prompt = `너는 특수교육 교사를 돕는 전문가야. 아래 정보를 참고하여 ${subject.name} 교과의 월별 계획을 JSON 배열로 작성해줘.\n\n- 학기: ${currentIepSemester}학기\n- 월 목록: ${monthLabels.join(', ')}\n- 학기 교육목표:\n${semesterGoals.map((goal, idx) => `${idx + 1}. ${goal}`).join('\n')}\n- 참고 성취기준:\n${achievementText}\n\n요구사항:\n1. 학기 교육목표의 핵심을 순서대로 ${monthLabels.length}개의 월별 교육목표로 나누어 제시한다. 필요한 경우 문장을 분할하거나 통합하되 모든 학기 목표 내용이 월별 목표에 반영되어야 한다.\n2. 각 월별 계획의 goal, content, method 값은 불릿 포인트 형식의 문자열로 작성한다. 불릿은 반드시 '○ '로 시작하고 문장마다 줄바꿈으로 구분한다.\n3. goal 항목은 2문장 이상, content와 method 항목은 각각 3문장 이상으로 작성한다.\n4. evaluation 항목을 포함하여 각 월 평가 기준을 작성한다. 평가 항목은 3문장으로 구성하고 각 문장은 '○ '로 시작하며 문장 끝은 차례대로 '~가', '~하는가', '~는가'로 끝나야 한다.\n5. content 항목의 모든 문장은 마침표 없이 '~기' 형태(예: ...하기, ...쓰기)로 끝나도록 작성한다.\n6. 모든 문장은 자연스러운 한국어로 작성한다.\n7. 응답은 반드시 JSON 배열만으로 제공하고 다른 설명은 포함하지 않는다.\n8. 배열의 각 요소는 {"month":"${monthLabels[0]}","goal":"...","content":"...","method":"...","evaluation":"..."} 형식을 따르며, month 값은 월 목록과 정확히 일치하고 순서를 유지해야 한다.`;
             const result = await callGemini(prompt, true);
             let plans = [];
             if (Array.isArray(result)) {
@@ -1848,7 +2023,7 @@
                     goal: formatMonthlyGoalText(plan.goal || ''),
                     content: formatMonthlyContentText(plan.content || ''),
                     method: formatMonthlyMethodText(plan.method || ''),
-                    evaluation: ''
+                    evaluation: formatMonthlyEvaluationText(plan.evaluation || '')
                 };
             });
         }
@@ -1972,6 +2147,9 @@
                     trimmed = trimmed.replace(/기\s*(?:한다|합니다|함)?$/, '기');
                     trimmed = trimmed.replace(/한다$/, '한다').replace(/합니다$/, '하기');
                     trimmed = trimmed.trim();
+                } else if (endingMode === 'none') {
+                    trimmed = trimmed.replace(/[.!?]\s*$/, '');
+                    trimmed = trimmed.trim();
                 } else {
                     trimmed = trimmed.replace(/[.!?]\s*$/, '');
                     trimmed = `${trimmed}.`;
@@ -1989,7 +2167,11 @@
                     fallback = fallback.replace(/기\s*(?:한다|합니다|함)?$/, '기');
                     fallback = fallback.replace(/한다$/, '한다').replace(/합니다$/, '하기');
                 }
-                const sentence = endingMode === 'gerund' ? fallback : `${fallback}.`;
+                const sentence = endingMode === 'gerund'
+                    ? fallback
+                    : endingMode === 'none'
+                        ? fallback
+                        : `${fallback}.`;
                 const bulletLine = `○ ${sentence}`;
                 return Array.from({ length: Math.max(minCount, 1) }, () => bulletLine).join('\n');
             }
@@ -2014,6 +2196,48 @@
         function formatMonthlyMethodText(text) {
             const bulletText = ensureBulletString(text, { minCount: 3, endingMode: 'period' });
             return enforceMethodSentenceEndings(bulletText);
+        }
+
+        function formatMonthlyEvaluationText(text) {
+            const endings = ['가', '하는가', '는가'];
+            const defaults = [
+                '○ 학습 목표 달성 여부가',
+                '○ 수업 참여 행동을 지속하는가',
+                '○ 학습 내용을 실제로 이해했는가'
+            ];
+            const bulletText = ensureBulletString(text, { minCount: endings.length, endingMode: 'none' });
+            const lines = (bulletText ? bulletText.split('\n') : [])
+                .map(line => line.trim())
+                .filter(Boolean);
+            const normalized = [];
+            for (let i = 0; i < endings.length; i++) {
+                const ending = endings[i];
+                let sourceLine = lines[i] || lines[lines.length - 1] || '';
+                if (!sourceLine) {
+                    normalized.push(defaults[i] || `○ 평가 문장${i + 1}${ending}`);
+                    continue;
+                }
+                const match = sourceLine.match(/^(○\s*)(.*)$/);
+                const prefix = match ? match[1] : '○ ';
+                let sentence = match ? match[2].trim() : sourceLine.replace(/^[-*•●]\s*/, '').trim();
+                if (!sentence) {
+                    normalized.push(defaults[i] || `○ 평가 문장${i + 1}${ending}`);
+                    continue;
+                }
+                sentence = sentence.replace(/[.!?]\s*$/, '');
+                sentence = sentence.replace(/\s+/g, ' ').trim();
+                if (!sentence.endsWith(ending)) {
+                    sentence = sentence.replace(/(인가요?|인가|인지|한가요?|한가|하는가요?|하는지|는가요?|는지|수 있는가요?|수 있는가|수 있는지|가능한가요?|가능한가|가능한지|될 수 있는가|될 수 있는지|되는지)\s*$/, '').trim();
+                    if (!sentence.endsWith(ending)) {
+                        if (sentence.endsWith('가') && ending !== '가') {
+                            sentence = sentence.slice(0, -1);
+                        }
+                        sentence = `${sentence}${ending}`;
+                    }
+                }
+                normalized.push(`${prefix}${sentence}`);
+            }
+            return normalized.join('\n');
         }
 
         function enforceMethodSentenceEndings(text) {


### PR DESCRIPTION
## Summary
- Replace the IEP modify dropdown with a button-driven target selector, expose the generation controls in a new "생성 테이블" section, and add a manual edit toggle.
- Refresh modify-target rendering and event wiring so sidebar buttons stay in sync with regenerated pages and AI updates.
- Request and normalize three evaluation bullet sentences for each monthly plan, ensuring the new '~가/~하는가/~는가' endings populate the 교육 평가 column.

## Testing
- No automated tests were run (not provided).


------
https://chatgpt.com/codex/tasks/task_e_68cabbaadf9c832e8c266115f303ee22