### PR TITLE
Ensure consistent pastel style for book illustrations

### DIFF
--- a/public/book.html
+++ b/public/book.html
@@ -590,6 +590,8 @@
          * 이미지 생성 API를 모방하는 함수입니다.
          * 실제로는 서버에 요청을 보내야 하지만, 여기서는 플레이스홀더 이미지 URL을 반환합니다.
          */
+        const IMAGE_STYLE_INSTRUCTION = "모든 장면은 부드럽고 몽환적인 파스텔톤의 아기자기한 그림체로 통일하고, 표지와 등장인물, 줄거리 장면이 동일한 색감과 분위기로 이어지도록 해주세요.";
+
         async function translateToEnglish(text) {
             try {
                 const payload = {
@@ -609,9 +611,12 @@
         }
 
         async function generateImageForParagraph(text, context = "") {
-            const basePrompt = `${text}\n${context}`.trim();
+            const promptParts = [text];
+            if (context) promptParts.push(context);
+            promptParts.push(IMAGE_STYLE_INSTRUCTION);
+            const basePrompt = promptParts.filter(Boolean).join('\n');
             const englishPrompt = await translateToEnglish(basePrompt);
-            const finalPrompt = `${englishPrompt}, bright, child-friendly, storybook style`;
+            const finalPrompt = `${englishPrompt}, soft dreamy pastel colors, cohesive whimsical storybook illustration, consistent color palette`;
             const res = await fetch('/.netlify/functions/stability-handler', {
                 method: 'POST',
                 headers: {
@@ -652,9 +657,12 @@
         }
 
         async function generateImageForParagraphGPT(text, context = "") {
-            const basePrompt = `${text}\n${context}`.trim();
+            const promptParts = [text];
+            if (context) promptParts.push(context);
+            promptParts.push(IMAGE_STYLE_INSTRUCTION);
+            const basePrompt = promptParts.filter(Boolean).join('\n');
             const englishPrompt = await translateToEnglish(basePrompt);
-            const finalPrompt = `${englishPrompt}, bright, child-friendly, storybook style`;
+            const finalPrompt = `${englishPrompt}, soft dreamy pastel colors, cohesive whimsical storybook illustration, consistent color palette`;
             const res = await fetch('/.netlify/functions/gpt-handler', {
                 method: 'POST',
                 headers: {
@@ -1155,33 +1163,44 @@
                         }
                         if (prompt) {
                             contextParts.push(prompt);
-                            const charPrompt = `${prompt}, white background, single character`;
+                            const charPrompt = `${prompt}, 동일한 파스텔 색감과 몽환적인 분위기를 지닌 단일 캐릭터 장면`;
                             const charImage = await generateImageForParagraph(charPrompt, '');
                             charImageBoxes[i].style.backgroundImage = `url('${charImage}')`;
                             charImageBoxes[i].textContent = '';
                         }
                     }
                 }
-                const context = contextParts.join('\n');
+                const characterContext = contextParts.join('\n');
 
                 // 표지 이미지 생성
                 const coverSpread = document.querySelector('#spread-0');
                 const coverPrompt = coverSpread?.dataset.prompt || document.querySelector("#spread-0 .book-title-sync").textContent;
-                const coverImage = await generateImageForParagraph(coverPrompt, '');
+                const coverImage = await generateImageForParagraph(coverPrompt, characterContext);
                 document.querySelector("#spread-0 .book-page:last-child").style.backgroundImage = `url('${coverImage}')`;
 
                 // 각 이야기 페이지 이미지 생성
                 const storySpreads = document.querySelectorAll('.book-spread[data-page-type="story"]');
+                const storyContextParts = [];
+                if (characterContext) {
+                    storyContextParts.push(`등장인물 정보: ${characterContext}`);
+                }
                 for (const spread of storySpreads) {
                     const storyText = spread.querySelector("textarea").value;
                     const extra = spread.dataset.prompt || '';
                     const prompt = `${storyText}\n${extra}`.trim();
                     if (prompt) {
-                        const imageUrl = await generateImageForParagraph(prompt, context);
+                        const combinedContext = storyContextParts.join('\n');
+                        const imageUrl = await generateImageForParagraph(prompt, combinedContext);
                         const imagePage = spread.querySelector(".book-page:first-child");
                         const pageNumHTML = imagePage.querySelector('.page-number')?.outerHTML || '';
                         imagePage.style.backgroundImage = `url('${imageUrl}')`;
                         imagePage.innerHTML = pageNumHTML;
+                        if (storyText) {
+                            storyContextParts.push(`이전 줄거리: ${storyText}`);
+                        }
+                        if (extra) {
+                            storyContextParts.push(`이전 추가 설명: ${extra}`);
+                        }
                     }
                 }
                 showNotification("책이 완성되었습니다! 이제 도서관에 등록할 수 있습니다.");
@@ -1256,33 +1275,44 @@
                         }
                         if (prompt) {
                             contextParts.push(prompt);
-                            const charPrompt = `${prompt}, white background, single character`;
+                            const charPrompt = `${prompt}, 동일한 파스텔 색감과 몽환적인 분위기를 지닌 단일 캐릭터 장면`;
                             const charImage = await generateImageForParagraphGPT(charPrompt, '');
                             charImageBoxes[i].style.backgroundImage = `url('${charImage}')`;
                             charImageBoxes[i].textContent = '';
                         }
                     }
                 }
-                const context = contextParts.join('\n');
+                const characterContext = contextParts.join('\n');
 
                 // 표지 이미지 생성
                 const coverSpread = document.querySelector('#spread-0');
                 const coverPrompt = coverSpread?.dataset.prompt || document.querySelector("#spread-0 .book-title-sync").textContent;
-                const coverImage = await generateImageForParagraphGPT(coverPrompt, '');
+                const coverImage = await generateImageForParagraphGPT(coverPrompt, characterContext);
                 document.querySelector("#spread-0 .book-page:last-child").style.backgroundImage = `url('${coverImage}')`;
 
                 // 각 이야기 페이지 이미지 생성
                 const storySpreads = document.querySelectorAll('.book-spread[data-page-type="story"]');
+                const storyContextParts = [];
+                if (characterContext) {
+                    storyContextParts.push(`등장인물 정보: ${characterContext}`);
+                }
                 for (const spread of storySpreads) {
                     const storyText = spread.querySelector("textarea").value;
                     const extra = spread.dataset.prompt || '';
                     const prompt = `${storyText}\n${extra}`.trim();
                     if (prompt) {
-                        const imageUrl = await generateImageForParagraphGPT(prompt, context);
+                        const combinedContext = storyContextParts.join('\n');
+                        const imageUrl = await generateImageForParagraphGPT(prompt, combinedContext);
                         const imagePage = spread.querySelector(".book-page:first-child");
                         const pageNumHTML = imagePage.querySelector('.page-number')?.outerHTML || '';
                         imagePage.style.backgroundImage = `url('${imageUrl}')`;
                         imagePage.innerHTML = pageNumHTML;
+                        if (storyText) {
+                            storyContextParts.push(`이전 줄거리: ${storyText}`);
+                        }
+                        if (extra) {
+                            storyContextParts.push(`이전 추가 설명: ${extra}`);
+                        }
                     }
                 }
                 showNotification("책이 완성되었습니다! 이제 도서관에 등록할 수 있습니다.");


### PR DESCRIPTION
## Summary
- enforce shared dreamy pastel illustration instructions for cover, character, and story image generation
- reuse character context and accumulated story beats when creating cover and story art so each scene reflects earlier content
- refine character prompts to request single-character scenes that align with the unified pastel style

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cb7a3bbca8832eb838e79439f9daa8