### PR TITLE
Allow students to store copy promise history

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -64,6 +64,12 @@ service cloud.firestore {
           if request.auth != null && request.auth.uid == userId;
       }
 
+      // ✨ [따라쓰기 약속] 완료 기록
+      match /copyPromiseHistory/{historyId} {
+        allow read, write, create, delete:
+          if request.auth != null && (request.auth.uid == userId || isTeacher());
+      }
+
       // ✨ [📚 에이두 북메이커] 사용자 전용 책 초안
       match /bookDrafts/{draftId} {
         allow read, write, create, delete:


### PR DESCRIPTION
## Summary
- add Firestore security rules for the new copyPromiseHistory sub-collection under each user
- allow authenticated owners and teachers to create, read, update, and delete copy promise history documents

## Testing
- not run (rules change only)


------
https://chatgpt.com/codex/tasks/task_e_68cccb2148b0832ebf35ec06e7601846