### PR TITLE
Align class creation between dashboard and book

### DIFF
--- a/public/book.html
+++ b/public/book.html
@@ -280,6 +280,7 @@
         import { getAuth, onAuthStateChanged, signInWithEmailAndPassword, GoogleAuthProvider, signInWithPopup, signOut, createUserWithEmailAndPassword } from "https://www.gstatic.com/firebasejs/11.6.1/firebase-auth.js";
         import { getFirestore, doc, getDoc, setDoc, serverTimestamp, updateDoc, increment, collection, addDoc, getDocs, query, where, runTransaction, arrayUnion, deleteDoc, getCountFromServer } from "https://www.gstatic.com/firebasejs/11.6.1/firebase-firestore.js";
         import { getStorage, ref as storageRef, uploadBytes, getDownloadURL, getBlob } from "https://www.gstatic.com/firebasejs/11.6.1/firebase-storage.js";
+        import { fetchTeacherClass, createTeacherClass, addStudentsToTeacherClass } from "./js/classManager.js";
 
         // 전역 변수
         let bookCurrentPage = 0;
@@ -1176,45 +1177,44 @@
             if (!bookAuthorUid) {
                 teacherClasses = [];
                 currentClassStudents = [];
+                selectedClassId = null;
                 if (!skipLibraryRender) renderLibraryBooks();
                 return;
             }
             try {
-                const classCollectionRef = collection(db, 'classes', bookAuthorUid, 'classrooms');
-                const snapshot = await getDocs(classCollectionRef);
-                teacherClasses = snapshot.docs.map(docSnap => {
-                    const data = docSnap.data() || {};
-                    return {
-                        id: docSnap.id,
-                        name: data.name || '이름 없는 학급',
-                        students: Array.isArray(data.students) ? data.students : [],
-                        createdAt: data.createdAt || null
-                    };
-                }).sort((a, b) => {
-                    const aTime = a.createdAt?.seconds ?? a.createdAt?.toMillis?.() ?? 0;
-                    const bTime = b.createdAt?.seconds ?? b.createdAt?.toMillis?.() ?? 0;
-                    return aTime - bTime;
-                });
-
-                if (!keepSelection || !teacherClasses.some(cls => cls.id === selectedClassId)) {
-                    selectedClassId = teacherClasses[0]?.id || null;
+                const classData = await fetchTeacherClass(db, bookAuthorUid);
+                if (classData) {
+                    teacherClasses = [{
+                        id: classData.id,
+                        name: classData.name || '이름 없는 학급',
+                        students: Array.isArray(classData.students) ? classData.students : []
+                    }];
+                    if (!keepSelection || !selectedClassId) {
+                        selectedClassId = classData.id;
+                    }
+                    currentClassStudents = Array.isArray(classData.students) ? classData.students : [];
+                } else {
+                    teacherClasses = [];
+                    currentClassStudents = [];
+                    if (!keepSelection) {
+                        selectedClassId = null;
+                    }
                 }
-
-                const unionSet = new Set();
-                teacherClasses.forEach(cls => {
-                    (cls.students || []).forEach(id => unionSet.add(id));
-                });
-                currentClassStudents = Array.from(unionSet);
 
                 if (!skipLibraryRender) {
                     renderLibraryBooks();
                     updateLibraryTeacherControls();
                 }
+                updateAddClassButtonState();
             } catch (error) {
                 console.error('Failed to load class students:', error);
                 teacherClasses = [];
                 currentClassStudents = [];
+                if (!keepSelection) {
+                    selectedClassId = null;
+                }
                 if (!skipLibraryRender) renderLibraryBooks();
+                updateAddClassButtonState();
             }
         }
 
@@ -2604,6 +2604,7 @@
                 emptyEl.textContent = '생성된 학급이 없습니다. 학급을 추가해 주세요.';
                 myClassList.appendChild(emptyEl);
                 setAddStudentButtonState(false);
+                updateAddClassButtonState();
                 return;
             }
 
@@ -2621,6 +2622,7 @@
             });
 
             setAddStudentButtonState(Boolean(selectedClassId));
+            updateAddClassButtonState();
         }
 
         function setAddStudentButtonState(enabled) {
@@ -2628,6 +2630,14 @@
             addMyClassStudentBtn.disabled = !enabled;
             addMyClassStudentBtn.classList.toggle('opacity-50', !enabled);
             addMyClassStudentBtn.classList.toggle('cursor-not-allowed', !enabled);
+        }
+
+        function updateAddClassButtonState() {
+            if (!addClassBtn) return;
+            const canAdd = teacherClasses.length === 0;
+            addClassBtn.disabled = !canAdd;
+            addClassBtn.classList.toggle('opacity-50', !canAdd);
+            addClassBtn.classList.toggle('cursor-not-allowed', !canAdd);
         }
 
         async function renderSelectedClassStudents() {
@@ -2673,6 +2683,10 @@
         function openAddClassModal() {
             if (!bookAuthorUid) { showNotification('로그인 후 이용해주세요.'); return; }
             if (!addClassModal) return;
+            if (teacherClasses.length > 0) {
+                showNotification('이미 생성된 학급이 있습니다.');
+                return;
+            }
             newClassNameInput.value = '';
             addClassModal.classList.remove('hidden');
             setTimeout(() => newClassNameInput.focus(), 0);
@@ -2688,18 +2702,17 @@
             if (!bookAuthorUid) { showNotification('로그인 후 이용해주세요.'); return; }
             const className = newClassNameInput.value.trim();
             if (!className) { showNotification('학급 이름을 입력하세요.'); return; }
+            if (teacherClasses.length > 0) {
+                showNotification('이미 생성된 학급이 있습니다.');
+                closeAddClassModal();
+                return;
+            }
             const originalText = confirmAddClassBtn.textContent;
             confirmAddClassBtn.disabled = true;
             confirmAddClassBtn.textContent = '생성 중...';
             try {
-                const classCollectionRef = collection(db, 'classes', bookAuthorUid, 'classrooms');
-                const newClassRef = doc(classCollectionRef);
-                await setDoc(newClassRef, {
-                    name: className,
-                    students: [],
-                    createdAt: serverTimestamp()
-                });
-                selectedClassId = newClassRef.id;
+                const newClassId = await createTeacherClass(db, bookAuthorUid, className);
+                selectedClassId = newClassId;
                 closeAddClassModal();
                 await loadTeacherClassStudents({ keepSelection: true });
                 renderClassList();
@@ -2755,8 +2768,7 @@
                 return;
             }
             try {
-                const classRef = doc(db, 'classes', bookAuthorUid, 'classrooms', selectedClassId);
-                await updateDoc(classRef, { students: arrayUnion(...selected) });
+                await addStudentsToTeacherClass(db, bookAuthorUid, selected);
                 showNotification('학생이 학급에 추가되었습니다.');
             } catch (error) {
                 console.error('Failed to add students to class:', error);

--- a/public/index.html
+++ b/public/index.html
@@ -1185,6 +1185,7 @@
         import { getFirestore, doc, getDoc, setDoc, collection, query, where, getDocs, runTransaction, updateDoc, increment, deleteField, serverTimestamp, Timestamp, orderBy, addDoc, deleteDoc, arrayUnion } from "https://www.gstatic.com/firebasejs/11.6.1/firebase-firestore.js";
         import { getFunctions, httpsCallable } from "https://www.gstatic.com/firebasejs/11.6.1/firebase-functions.js";
         import { getStorage, ref as storageRef, getDownloadURL, deleteObject } from "https://www.gstatic.com/firebasejs/11.6.1/firebase-storage.js";
+        import { createTeacherClass } from "./js/classManager.js";
 
         // IMPORTANT: Replace with your actual Firebase config
         const firebaseConfig = {
@@ -3779,7 +3780,7 @@
                         const name = prompt('학급 이름을 입력하세요');
                         if (name) {
                             try {
-                                await setDoc(docRef, { name, students: [] });
+                                await createTeacherClass(db, currentUserData.id, name);
                                 loadMyClass();
                             } catch (err) {
                                 container.innerHTML = '<p class="text-red-500 text-center">학급 생성 실패</p>';

--- a/public/js/classManager.js
+++ b/public/js/classManager.js
@@ -1,0 +1,52 @@
+import { doc, getDoc, setDoc, updateDoc, arrayUnion } from "https://www.gstatic.com/firebasejs/11.6.1/firebase-firestore.js";
+
+function getClassDocRef(db, teacherId) {
+    if (!db) throw new Error('Firestore 인스턴스가 필요합니다.');
+    if (!teacherId) throw new Error('교사 ID가 필요합니다.');
+    return doc(db, 'classes', teacherId);
+}
+
+export async function fetchTeacherClass(db, teacherId) {
+    const classRef = getClassDocRef(db, teacherId);
+    const snapshot = await getDoc(classRef);
+    if (!snapshot.exists()) {
+        return null;
+    }
+    const data = snapshot.data() || {};
+    const students = Array.isArray(data.students) ? data.students : [];
+    return {
+        id: classRef.id,
+        name: data.name || '',
+        students
+    };
+}
+
+export async function createTeacherClass(db, teacherId, className) {
+    if (!className) {
+        throw new Error('학급 이름이 필요합니다.');
+    }
+    const classRef = getClassDocRef(db, teacherId);
+    const existing = await getDoc(classRef);
+    if (existing.exists()) {
+        await updateDoc(classRef, { name: className });
+    } else {
+        await setDoc(classRef, { name: className, students: [] });
+    }
+    return classRef.id;
+}
+
+export async function addStudentsToTeacherClass(db, teacherId, studentIds) {
+    if (!Array.isArray(studentIds) || studentIds.length === 0) {
+        return;
+    }
+    const classRef = getClassDocRef(db, teacherId);
+    await updateDoc(classRef, { students: arrayUnion(...studentIds) });
+}
+
+export async function updateTeacherClassStudents(db, teacherId, students) {
+    if (!Array.isArray(students)) {
+        throw new Error('학생 목록은 배열이어야 합니다.');
+    }
+    const classRef = getClassDocRef(db, teacherId);
+    await updateDoc(classRef, { students });
+}


### PR DESCRIPTION
## Summary
- add a shared class management helper that works with the existing `classes/{teacherId}` document structure
- update index.html to use the shared class creation helper for "내 학급" creation
- refactor book.html to consume the shared helper, ensuring it reads and updates the same class document while disabling duplicate class creation

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68d0d5b24f1c832e9dce0a045991e588