### PR TITLE
Relax class read rules for students

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -227,11 +227,17 @@ service cloud.firestore {
     match /classes/{teacherId} {
       allow get, update, delete: if request.auth.uid == teacherId && isTeacher();
       allow create: if request.auth.uid == teacherId && isTeacher();
+
       allow list: if isTeacher() ||
-        (isStudent() &&
+        (request.auth != null &&
          request.query != null &&
          request.query.where('students', 'array-contains', request.auth.uid));
-      allow get: if isStudent() && resource.data.students != null && request.auth.uid in resource.data.students;
+
+      allow get: if
+        (request.auth.uid == teacherId && isTeacher()) ||
+        (request.auth != null &&
+         resource.data.students != null &&
+         request.auth.uid in resource.data.students);
     }
 
     // 'IEP 에이두' 앱 규칙


### PR DESCRIPTION
## Summary
- loosen Firestore list permissions on the classes collection so students can execute filtered queries for their own class assignments
- allow class document reads when the authenticated user belongs to the class while retaining teacher-only access for administrative operations

## Testing
- not run (rules change only)


------
https://chatgpt.com/codex/tasks/task_e_68d355c290c8832e86a59511fe6a1263