### PR TITLE
Allow shared behavior cache updates by recipients

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -136,8 +136,14 @@ service cloud.firestore {
       // ✨ [에이두 스페셜] 공유 받은 행동 기록 인덱스
       match /sharedBehaviors/{sharedId} {
         allow read: if request.auth.uid == userId || isTeacher();
-        allow create, update: if isTeacher() && request.resource.data.ownerId == request.auth.uid;
-        allow delete: if isTeacher() && resource.data.ownerId == request.auth.uid;
+        allow create, update: if isTeacher() && (
+          request.resource.data.ownerId == request.auth.uid ||
+          request.auth.uid == userId
+        );
+        allow delete: if isTeacher() && (
+          resource.data.ownerId == request.auth.uid ||
+          request.auth.uid == userId
+        );
       }
     }
 


### PR DESCRIPTION
## Summary
- allow teachers to create or update shared behavior cache documents when they are the recipient of a shared record
- permit shared behavior recipients to remove cached entries they no longer need

## Testing
- not run (rules change only)


------
https://chatgpt.com/codex/tasks/task_e_68d5d821a808832ead2d5de2f21e85e3