### PR TITLE
Add Aiedu sketchbook sidebar to behavior view

### DIFF
--- a/public/special.html
+++ b/public/special.html
@@ -403,7 +403,7 @@
                                 <h3 class="text-lg sm:text-xl font-bold text-slate-800">🎨 에이두 스케치북</h3>
                                 <p class="text-xs text-slate-500">수업 자료와 활동을 자유롭게 기록해보세요.</p>
                             </div>
-                            <button id="create-sketch-btn" class="self-start rounded-md bg-sky-600 px-3 py-2 text-xs sm:text-sm font-semibold text-white shadow-sm transition hover:bg-sky-700">스케치북 만들기</button>
+                            <button data-action="create-sketch" class="self-start rounded-md bg-sky-600 px-3 py-2 text-xs sm:text-sm font-semibold text-white shadow-sm transition hover:bg-sky-700">스케치북 만들기</button>
                         </div>
                         <ul id="sketchbook-list" class="space-y-2 max-h-80 overflow-y-auto">
                             <li class="text-sm text-gray-500">스케치북을 불러오는 중입니다...</li>
@@ -621,8 +621,24 @@
                                         <span>추가</span>
                                     </button>
                                 </div>
-                                <div id="behavior-record-list" class="space-y-2">
-                                    <p class="text-sm text-gray-500">학생을 선택하면 행동 기록이 표시됩니다.</p>
+                                <div class="flex flex-col xl:flex-row gap-6">
+                                    <div class="flex-1">
+                                        <div id="behavior-record-list" class="space-y-2">
+                                            <p class="text-sm text-gray-500">학생을 선택하면 행동 기록이 표시됩니다.</p>
+                                        </div>
+                                    </div>
+                                    <aside class="w-full xl:w-80 rounded-lg border border-slate-200 bg-slate-50 p-4">
+                                        <div class="flex items-start justify-between gap-3">
+                                            <div>
+                                                <h4 class="text-base font-semibold text-slate-800">🎨 에이두 스케치북</h4>
+                                                <p class="mt-1 text-xs text-slate-500">수업 자료와 활동을 바로 확인해보세요.</p>
+                                            </div>
+                                            <button data-action="create-sketch" class="rounded-md bg-sky-600 px-3 py-1.5 text-xs font-semibold text-white shadow-sm transition hover:bg-sky-700">만들기</button>
+                                        </div>
+                                        <ul id="behavior-sketchbook-list" class="mt-4 space-y-2 max-h-72 overflow-y-auto">
+                                            <li class="text-sm text-gray-500">스케치북을 불러오는 중입니다...</li>
+                                        </ul>
+                                    </aside>
                                 </div>
                             </div>
                             <div id="behavior-detail-panel" class="bg-white p-6 rounded-lg shadow-lg hidden">
@@ -858,8 +874,16 @@
         const userEmailSpan = document.getElementById('user-email');
         const homeBehaviorTable = document.getElementById('home-behavior-table');
         const homeBehaviorRefreshBtn = document.getElementById('home-behavior-refresh');
-        const createSketchBtn = document.getElementById('create-sketch-btn');
         const sketchbookListEl = document.getElementById('sketchbook-list');
+        const behaviorSketchbookListEl = document.getElementById('behavior-sketchbook-list');
+        const createSketchButtons = Array.from(document.querySelectorAll('[data-action="create-sketch"]'));
+        const sketchbookListContainers = [sketchbookListEl, behaviorSketchbookListEl].filter(Boolean);
+
+        function setSketchbookListMessage(html) {
+            sketchbookListContainers.forEach(container => {
+                container.innerHTML = html;
+            });
+        }
         const toast = document.getElementById('toast');
         const levelButtons = document.getElementById('level-buttons');
         const subjectButtons = document.getElementById('subject-buttons');
@@ -1232,8 +1256,8 @@
                 if (studentCodeInput) studentCodeInput.value = '';
                 if (teacherEmailInput) teacherEmailInput.value = '';
                 if (teacherPasswordInput) teacherPasswordInput.value = '';
-                if (sketchbookListEl) {
-                    sketchbookListEl.innerHTML = '<li class="text-sm text-gray-500">스케치북을 불러오려면 로그인해주세요.</li>';
+                if (sketchbookListContainers.length) {
+                    setSketchbookListMessage('<li class="text-sm text-gray-500">스케치북을 불러오려면 로그인해주세요.</li>');
                 }
             }
         });
@@ -1483,12 +1507,83 @@
             return code;
         }
 
+        function createSketchbookListItem(sketch) {
+            const li = document.createElement('li');
+            li.className = 'p-3 bg-white rounded border border-slate-200 shadow-sm flex items-center justify-between gap-4';
+
+            const infoBtn = document.createElement('button');
+            infoBtn.type = 'button';
+            infoBtn.className = 'flex-1 text-left';
+            const sketchName = escapeHtml(sketch.name || '새 스케치북');
+            const sketchCode = escapeHtml(sketch.code || '생성 중');
+            infoBtn.innerHTML = `
+                <div class="font-semibold text-slate-800">${sketchName}</div>
+                <div class="text-xs text-slate-500 mt-1">코드: ${sketchCode}</div>
+            `;
+            infoBtn.addEventListener('click', () => {
+                window.open(`sketch.html?sketchId=${encodeURIComponent(sketch.id)}&code=${encodeURIComponent(sketch.code || '')}`, '_blank');
+            });
+            li.appendChild(infoBtn);
+
+            const buttonGroup = document.createElement('div');
+            buttonGroup.className = 'flex items-center gap-3';
+
+            const renameBtn = document.createElement('button');
+            renameBtn.type = 'button';
+            renameBtn.className = 'text-sm text-sky-600 hover:underline';
+            renameBtn.textContent = '이름 변경';
+            renameBtn.addEventListener('click', async (event) => {
+                event.preventDefault();
+                const user = auth.currentUser;
+                if (!user) return;
+                const newName = prompt('새 이름을 입력하세요', sketch.name || '새 스케치북');
+                if (!newName) return;
+                try {
+                    await updateDoc(doc(db, 'users', user.uid, 'sketches', sketch.id), { name: newName });
+                    await renderSketchbookList();
+                } catch (error) {
+                    console.error('Failed to rename sketchbook', error);
+                    alert('스케치북 이름을 변경하지 못했습니다. 잠시 후 다시 시도해주세요.');
+                }
+            });
+            buttonGroup.appendChild(renameBtn);
+
+            const deleteBtn = document.createElement('button');
+            deleteBtn.type = 'button';
+            deleteBtn.className = 'text-sm text-red-500 hover:underline';
+            deleteBtn.textContent = '삭제';
+            deleteBtn.addEventListener('click', async (event) => {
+                event.preventDefault();
+                const user = auth.currentUser;
+                if (!user) return;
+                if (!confirm('정말 삭제하시겠습니까?')) return;
+                try {
+                    await deleteDoc(doc(db, 'users', user.uid, 'sketches', sketch.id));
+                    try {
+                        await deleteObject(storageRef(storage, `sketch/${user.uid}/${sketch.id}.excalidraw`));
+                    } catch (storageError) {
+                        if (storageError?.code !== 'storage/object-not-found') {
+                            console.error('Failed to delete sketch file', storageError);
+                        }
+                    }
+                    await renderSketchbookList();
+                } catch (error) {
+                    console.error('Failed to delete sketchbook', error);
+                    alert('스케치북을 삭제하지 못했습니다. 잠시 후 다시 시도해주세요.');
+                }
+            });
+            buttonGroup.appendChild(deleteBtn);
+
+            li.appendChild(buttonGroup);
+            return li;
+        }
+
         async function renderSketchbookList() {
             const user = auth.currentUser;
-            if (!user || !sketchbookListEl) return;
+            if (!user || !sketchbookListContainers.length) return;
             if (isLoadingSketchbooks) return;
             isLoadingSketchbooks = true;
-            sketchbookListEl.innerHTML = '<li class="p-3 text-sm text-gray-500">스케치북을 불러오는 중입니다...</li>';
+            setSketchbookListMessage('<li class="p-3 text-sm text-gray-500">스케치북을 불러오는 중입니다...</li>');
             try {
                 const snap = await getDocs(collection(db, 'users', user.uid, 'sketches'));
                 const sketches = [];
@@ -1513,13 +1608,14 @@
                     }
                 }
 
-                sketchbookListEl.innerHTML = '';
-
                 if (!sketches.length) {
-                    const emptyMessage = document.createElement('li');
-                    emptyMessage.className = 'p-4 bg-slate-50 rounded text-center text-sm text-gray-500 border border-dashed border-slate-200';
-                    emptyMessage.textContent = '아직 만든 스케치북이 없습니다. 새로운 스케치북을 만들어보세요!';
-                    sketchbookListEl.appendChild(emptyMessage);
+                    sketchbookListContainers.forEach(container => {
+                        container.innerHTML = '';
+                        const emptyMessage = document.createElement('li');
+                        emptyMessage.className = 'p-4 bg-slate-50 rounded text-center text-sm text-gray-500 border border-dashed border-slate-200';
+                        emptyMessage.textContent = '아직 만든 스케치북이 없습니다. 새로운 스케치북을 만들어보세요!';
+                        container.appendChild(emptyMessage);
+                    });
                     return;
                 }
 
@@ -1529,75 +1625,15 @@
                     return timeB - timeA;
                 });
 
-                sketches.forEach(sketch => {
-                    const li = document.createElement('li');
-                    li.className = 'p-3 bg-white rounded border border-slate-200 shadow-sm flex items-center justify-between gap-4';
-
-                    const infoBtn = document.createElement('button');
-                    infoBtn.type = 'button';
-                    infoBtn.className = 'flex-1 text-left';
-                    const sketchName = escapeHtml(sketch.name || '새 스케치북');
-                    const sketchCode = escapeHtml(sketch.code || '생성 중');
-                    infoBtn.innerHTML = `
-                        <div class="font-semibold text-slate-800">${sketchName}</div>
-                        <div class="text-xs text-slate-500 mt-1">코드: ${sketchCode}</div>
-                    `;
-                    infoBtn.addEventListener('click', () => {
-                        window.open(`sketch.html?sketchId=${encodeURIComponent(sketch.id)}&code=${encodeURIComponent(sketch.code || '')}`, '_blank');
+                sketchbookListContainers.forEach(container => {
+                    container.innerHTML = '';
+                    sketches.forEach(sketch => {
+                        container.appendChild(createSketchbookListItem(sketch));
                     });
-                    li.appendChild(infoBtn);
-
-                    const buttonGroup = document.createElement('div');
-                    buttonGroup.className = 'flex items-center gap-3';
-
-                    const renameBtn = document.createElement('button');
-                    renameBtn.type = 'button';
-                    renameBtn.className = 'text-sm text-sky-600 hover:underline';
-                    renameBtn.textContent = '이름 변경';
-                    renameBtn.addEventListener('click', async (event) => {
-                        event.preventDefault();
-                        const newName = prompt('새 이름을 입력하세요', sketch.name || '새 스케치북');
-                        if (!newName) return;
-                        try {
-                            await updateDoc(doc(db, 'users', user.uid, 'sketches', sketch.id), { name: newName });
-                            await renderSketchbookList();
-                        } catch (error) {
-                            console.error('Failed to rename sketchbook', error);
-                            alert('스케치북 이름을 변경하지 못했습니다. 잠시 후 다시 시도해주세요.');
-                        }
-                    });
-                    buttonGroup.appendChild(renameBtn);
-
-                    const deleteBtn = document.createElement('button');
-                    deleteBtn.type = 'button';
-                    deleteBtn.className = 'text-sm text-red-500 hover:underline';
-                    deleteBtn.textContent = '삭제';
-                    deleteBtn.addEventListener('click', async (event) => {
-                        event.preventDefault();
-                        if (!confirm('정말 삭제하시겠습니까?')) return;
-                        try {
-                            await deleteDoc(doc(db, 'users', user.uid, 'sketches', sketch.id));
-                            try {
-                                await deleteObject(storageRef(storage, `sketch/${user.uid}/${sketch.id}.excalidraw`));
-                            } catch (storageError) {
-                                if (storageError?.code !== 'storage/object-not-found') {
-                                    console.error('Failed to delete sketch file', storageError);
-                                }
-                            }
-                            await renderSketchbookList();
-                        } catch (error) {
-                            console.error('Failed to delete sketchbook', error);
-                            alert('스케치북을 삭제하지 못했습니다. 잠시 후 다시 시도해주세요.');
-                        }
-                    });
-                    buttonGroup.appendChild(deleteBtn);
-
-                    li.appendChild(buttonGroup);
-                    sketchbookListEl.appendChild(li);
                 });
             } catch (error) {
                 console.error('Failed to load sketchbooks', error);
-                sketchbookListEl.innerHTML = '<li class="p-3 text-sm text-red-500">스케치북을 불러오지 못했습니다. 잠시 후 다시 시도해주세요.</li>';
+                setSketchbookListMessage('<li class="p-3 text-sm text-red-500">스케치북을 불러오지 못했습니다. 잠시 후 다시 시도해주세요.</li>');
             } finally {
                 isLoadingSketchbooks = false;
             }
@@ -1684,33 +1720,41 @@
             loadHomeBehaviorOverview({ force: true });
         });
 
-        createSketchBtn?.addEventListener('click', async () => {
-            const user = auth.currentUser;
-            if (!user || createSketchBtn.disabled) return;
-            createSketchBtn.disabled = true;
-            createSketchBtn.classList.add('opacity-50', 'cursor-not-allowed');
-            try {
-                const snap = await getDocs(collection(db, 'users', user.uid, 'sketches'));
-                const existingCodes = new Set();
-                snap.forEach(docSnap => {
-                    const data = docSnap.data() || {};
-                    if (data.code) existingCodes.add(data.code);
-                });
-                const newCode = generateUniqueSketchCode(existingCodes);
-                const docRef = await addDoc(collection(db, 'users', user.uid, 'sketches'), {
-                    name: '새 스케치북',
-                    createdAt: serverTimestamp(),
-                    code: newCode
-                });
-                await renderSketchbookList();
-                window.open(`sketch.html?sketchId=${encodeURIComponent(docRef.id)}&code=${encodeURIComponent(newCode)}`, '_blank');
-            } catch (error) {
-                console.error('Failed to create sketchbook', error);
-                alert('스케치북을 만들지 못했습니다. 잠시 후 다시 시도해주세요.');
-            } finally {
-                createSketchBtn.disabled = false;
-                createSketchBtn.classList.remove('opacity-50', 'cursor-not-allowed');
-            }
+        function setCreateSketchButtonsDisabled(disabled) {
+            createSketchButtons.forEach(btn => {
+                btn.disabled = disabled;
+                btn.classList.toggle('opacity-50', disabled);
+                btn.classList.toggle('cursor-not-allowed', disabled);
+            });
+        }
+
+        createSketchButtons.forEach(button => {
+            button.addEventListener('click', async () => {
+                const user = auth.currentUser;
+                if (!user || button.disabled) return;
+                setCreateSketchButtonsDisabled(true);
+                try {
+                    const snap = await getDocs(collection(db, 'users', user.uid, 'sketches'));
+                    const existingCodes = new Set();
+                    snap.forEach(docSnap => {
+                        const data = docSnap.data() || {};
+                        if (data.code) existingCodes.add(data.code);
+                    });
+                    const newCode = generateUniqueSketchCode(existingCodes);
+                    const docRef = await addDoc(collection(db, 'users', user.uid, 'sketches'), {
+                        name: '새 스케치북',
+                        createdAt: serverTimestamp(),
+                        code: newCode
+                    });
+                    await renderSketchbookList();
+                    window.open(`sketch.html?sketchId=${encodeURIComponent(docRef.id)}&code=${encodeURIComponent(newCode)}`, '_blank');
+                } catch (error) {
+                    console.error('Failed to create sketchbook', error);
+                    alert('스케치북을 만들지 못했습니다. 잠시 후 다시 시도해주세요.');
+                } finally {
+                    setCreateSketchButtonsDisabled(false);
+                }
+            });
         });
 
         homeBehaviorTable?.addEventListener('click', async (event) => {
@@ -5880,7 +5924,7 @@ ${JSON.stringify(entry.aiData, null, 2)}
             }
             resetBehaviorDetail();
             updateBehaviorActionState();
-            await Promise.all([loadBehaviorStudents(), loadSharedBehaviors()]);
+            await Promise.all([loadBehaviorStudents(), loadSharedBehaviors(), renderSketchbookList()]);
         }
 
         // --- UTILITY FUNCTIONS ---


### PR DESCRIPTION
## Summary
- add an Aiedu Sketchbook panel beside the behavior records so teachers can access sketchbooks from that view
- reuse the sketchbook rendering logic for both the home view and behavior view lists
- update the sketchbook creation handler to work with multiple "create" buttons

## Testing
- not run (project has no automated tests)


------
https://chatgpt.com/codex/tasks/task_e_68d617be0d60832e805e17b07387e365