### PR TITLE
Add dedicated Aiedu sketchbook view to special page

### DIFF
--- a/public/special.html
+++ b/public/special.html
@@ -373,6 +373,7 @@
                         <span id="user-email" class="text-[0.65rem] sm:text-xs text-gray-600"></span>
                         <a href="#home" id="nav-home" class="nav-link text-[0.7rem] sm:text-sm">홈</a>
                         <a href="#my-class" id="nav-my-class" class="nav-link text-[0.7rem] sm:text-sm">내 학급 관리</a>
+                        <a href="#sketchbook" id="nav-sketchbook" class="nav-link text-[0.7rem] sm:text-sm">에이두 스케치북</a>
                         <!-- IEP navigation link; '개별화교육계획' is commonly referred to as 'IEP'. Modify this section when updating 'iep'. -->
                         <a href="#iep" id="nav-iep" class="nav-link text-[0.7rem] sm:text-sm">개별화교육계획(IEP)</a>
                         <a href="#templates" id="nav-templates" class="nav-link text-[0.7rem] sm:text-sm">서식 생성</a>
@@ -397,20 +398,51 @@
                             <p class="text-sm text-gray-500">행동 기록을 불러오는 중입니다...</p>
                         </div>
                     </div>
-                    <div class="bg-white p-4 sm:p-6 rounded-lg shadow-lg">
-                        <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between mb-4">
-                            <div>
-                                <h3 class="text-lg sm:text-xl font-bold text-slate-800">🎨 에이두 스케치북</h3>
-                                <p class="text-xs text-slate-500">수업 자료와 활동을 자유롭게 기록해보세요.</p>
-                            </div>
-                            <button data-action="create-sketch" class="self-start rounded-md bg-sky-600 px-3 py-2 text-xs sm:text-sm font-semibold text-white shadow-sm transition hover:bg-sky-700">스케치북 만들기</button>
+                </div>
+
+                <!-- Sketchbook View -->
+                <div id="sketchbook-view" class="hidden space-y-6">
+                    <div class="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+                        <div>
+                            <h2 class="text-3xl font-bold">에이두 스케치북</h2>
+                            <p class="text-sm text-slate-500">수업 아이디어와 활동 자료를 한 곳에 모아보세요. 스케치북을 만들고 학생과 동료 교사와 손쉽게 공유할 수 있습니다.</p>
                         </div>
-                        <ul id="sketchbook-list" class="space-y-2 max-h-80 overflow-y-auto">
-                            <li class="text-sm text-gray-500">스케치북을 불러오는 중입니다...</li>
-                        </ul>
+                        <button data-action="create-sketch" class="self-start rounded-md bg-sky-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-sky-700">새 스케치북 만들기</button>
+                    </div>
+                    <div class="grid gap-6 lg:grid-cols-[2fr,1fr]">
+                        <div class="bg-white p-6 rounded-lg shadow-lg">
+                            <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between mb-4">
+                                <div>
+                                    <h3 class="text-xl font-semibold text-slate-800">내 스케치북</h3>
+                                    <p class="text-sm text-slate-500">최근 순으로 정리된 스케치북 목록입니다.</p>
+                                </div>
+                                <button data-action="create-sketch" class="rounded-md border border-sky-200 bg-white px-3 py-1.5 text-xs font-semibold text-sky-600 transition hover:bg-sky-50">빠르게 만들기</button>
+                            </div>
+                            <ul id="sketchbook-list" class="space-y-3 max-h-[520px] overflow-y-auto">
+                                <li class="text-sm text-gray-500">스케치북을 불러오는 중입니다...</li>
+                            </ul>
+                        </div>
+                        <div class="space-y-6">
+                            <div class="bg-white p-6 rounded-lg shadow-lg">
+                                <h3 class="text-base font-semibold text-slate-800">활용 가이드</h3>
+                                <ul class="mt-3 space-y-3 text-sm text-slate-600">
+                                    <li class="flex items-start gap-2"><span class="mt-1 inline-flex h-2 w-2 flex-shrink-0 rounded-full bg-sky-500"></span><span>수업 전 개요, 학습 자료, 평가 계획을 레이어별로 정리해 보세요.</span></li>
+                                    <li class="flex items-start gap-2"><span class="mt-1 inline-flex h-2 w-2 flex-shrink-0 rounded-full bg-emerald-500"></span><span>스케치북 코드로 동료 교사에게 공유하고 공동 작업을 진행하세요.</span></li>
+                                    <li class="flex items-start gap-2"><span class="mt-1 inline-flex h-2 w-2 flex-shrink-0 rounded-full bg-amber-500"></span><span>Excalidraw 파일을 불러와 기존 아이디어를 빠르게 수정할 수 있습니다.</span></li>
+                                </ul>
+                            </div>
+                            <div class="bg-sky-50 border border-sky-100 p-6 rounded-lg shadow-inner">
+                                <h3 class="text-base font-semibold text-sky-700">공유 팁</h3>
+                                <p class="mt-2 text-sm text-sky-700">공유받은 코드는 스케치북 상세 화면에서 입력할 수 있습니다. 학생과 함께 사용할 경우, 읽기 전용 링크를 복사해 안내하세요.</p>
+                                <div class="mt-4 space-y-2 text-xs text-sky-800">
+                                    <p class="flex items-start gap-2"><span class="mt-1 inline-flex h-2 w-2 flex-shrink-0 rounded-full bg-sky-600"></span>코드를 분실했다면 스케치북 카드에서 &lsquo;공유 코드 확인&rsquo;을 눌러 다시 확인할 수 있습니다.</p>
+                                    <p class="flex items-start gap-2"><span class="mt-1 inline-flex h-2 w-2 flex-shrink-0 rounded-full bg-sky-600"></span>학생과 실시간 수업을 진행할 땐 화면 공유와 함께 드로잉 모드를 활용해보세요.</p>
+                                </div>
+                            </div>
+                        </div>
                     </div>
                 </div>
-                
+
                 <!-- My Class View -->
                 <div id="my-class-view" class="hidden">
                     <h2 class="text-3xl font-bold mb-6">내 학급 관리</h2>
@@ -926,6 +958,7 @@
         const views = {
             home: document.getElementById('home-view'),
             'my-class': document.getElementById('my-class-view'),
+            sketchbook: document.getElementById('sketchbook-view'),
             iep: document.getElementById('iep-view'),
             templates: document.getElementById('templates-view'),
             behavior: document.getElementById('behavior-view'),
@@ -934,6 +967,7 @@
         const navLinks = {
             home: document.getElementById('nav-home'),
             'my-class': document.getElementById('nav-my-class'),
+            sketchbook: document.getElementById('nav-sketchbook'),
             iep: document.getElementById('nav-iep'),
             templates: document.getElementById('nav-templates'),
             behavior: document.getElementById('nav-behavior'),
@@ -1276,6 +1310,8 @@
                     await loadHomeData();
                 } else if (view === 'my-class') {
                     await loadClasses();
+                } else if (view === 'sketchbook') {
+                    await renderSketchbookList();
                 } else if (view === 'iep') {
                     loadIepStudents();
                     if (iepOutputContainer) {
@@ -1361,7 +1397,6 @@
             if (!user || isLoadingHomeData) return;
             isLoadingHomeData = true;
             loadHomeBehaviorOverview();
-            renderSketchbookList();
             try {
                 const classRef = doc(db, 'classes', user.uid);
                 const iepsRef = collection(db, 'users', user.uid, 'ieps');


### PR DESCRIPTION
## Summary
- add a navigation entry and dedicated view for the Aiedu sketchbook experience
- remove the sketchbook card from the home dashboard and surface enhanced guidance inside the new view
- ensure navigation logic loads sketchbook data when the new view is opened

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6232b3bc8832eb8b434a3d9d3290f