### PR TITLE
Remove duplicate sketchbook nav link

### DIFF
--- a/public/special.html
+++ b/public/special.html
@@ -373,12 +373,11 @@
                         <span id="user-email" class="text-[0.65rem] sm:text-xs text-gray-600"></span>
                         <a href="#home" id="nav-home" data-view="home" class="nav-link text-[0.7rem] sm:text-sm">홈</a>
                         <a href="#my-class" id="nav-my-class" data-view="my-class" class="nav-link text-[0.7rem] sm:text-sm">내 학급 관리</a>
-                        <a href="#sketchbook" id="nav-sketchbook" data-view="sketchbook" class="nav-link text-[0.7rem] sm:text-sm">에이두 스케치북</a>
                         <!-- IEP navigation link; '개별화교육계획' is commonly referred to as 'IEP'. Modify this section when updating 'iep'. -->
                         <a href="#iep" id="nav-iep" data-view="iep" class="nav-link text-[0.7rem] sm:text-sm">개별화교육계획(IEP)</a>
                         <a href="#templates" id="nav-templates" data-view="templates" class="nav-link text-[0.7rem] sm:text-sm">서식 생성</a>
                         <a href="#behavior" id="nav-behavior" data-view="behavior" class="nav-link text-[0.7rem] sm:text-sm">행동 기록</a>
-                        <a href="#sketchbook" id="nav-sketchbook-secondary" data-view="sketchbook" class="nav-link text-[0.7rem] sm:text-sm">에이두 스케치북</a>
+                        <a href="#sketchbook" id="nav-sketchbook" data-view="sketchbook" class="nav-link text-[0.7rem] sm:text-sm">에이두 스케치북</a>
                         <button id="logout-btn" class="text-xs sm:text-sm bg-red-500 hover:bg-red-600 text-white font-semibold py-1 px-3 rounded-md transition-colors">로그아웃</button>
                     </nav>
                 </div>


### PR DESCRIPTION
## Summary
- remove the duplicate Sketchbook navigation entry so only the right-side link remains
- keep the surviving link's identifier consistent for existing view logic

## Testing
- not run (HTML change)

------
https://chatgpt.com/codex/tasks/task_e_68d64fe47814832ebb5b1a94188356f6